### PR TITLE
Add unit tests for PostProcessAdmin

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   # if pip doesn't work https://stackoverflow.com/questions/49940813/pip-no-module-named-internal
   - pytest
   - pytest-cov
+  - pytest-mock
   - pip: # will need to be installed separately if pip is broken
     - stompest==2.1.6
 # needed for wheel - add when switching to python3

--- a/environment.yml
+++ b/environment.yml
@@ -4,10 +4,11 @@ channels:
   - defaults
 dependencies:
   - python=2.7
-  - pip
+  - pip<21.0
+  # if pip doesn't work https://stackoverflow.com/questions/49940813/pip-no-module-named-internal
   - pytest
   - pytest-cov
-  - pip:
+  - pip: # will need to be installed separately if pip is broken
     - stompest==2.1.6
 # needed for wheel - add when switching to python3
 #  - build

--- a/postprocessing/Configuration.py
+++ b/postprocessing/Configuration.py
@@ -81,8 +81,15 @@ class Configuration(object):
         self.mantid_path = (
             config["mantid_path"] if "mantid_path" in config else "/opt/Mantid/bin"
         )
+        # used to override /facility/instrument/shared
+        self.dev_instrument_shared = (
+            config["dev_instrument_shared"].strip()
+            if "dev_instrument_shared" in config
+            else ""
+        )
+        # used to override /facility/instrument/proposal/shared
         self.dev_output_dir = (
-            config["dev_output_dir"] if "dev_output_dir" in config else ""
+            config["dev_output_dir"].strip() if "dev_output_dir" in config else ""
         )
         self.python_executable = (
             config["python_exec"] if "python_exec" in config else "python"

--- a/postprocessing/PostProcessAdmin.py
+++ b/postprocessing/PostProcessAdmin.py
@@ -96,14 +96,16 @@ class PostProcessAdmin:
                 "shared",
                 "autoreduce",
             )
-            log_dir = os.path.join(proposal_shared_dir, "reduction_log")
-            if not os.path.exists(log_dir):
-                os.makedirs(log_dir)
 
             # Allow for an alternate output directory, if defined
             if len(self.conf.dev_output_dir.strip()) > 0:
                 proposal_shared_dir = self.conf.dev_output_dir
             logging.info("Using output directory: %s" % proposal_shared_dir)
+
+            # Set logging directory
+            log_dir = os.path.join(proposal_shared_dir, "reduction_log")
+            if not os.path.exists(log_dir):
+                os.makedirs(log_dir)
 
             # Look for run summary script
             summary_script = os.path.join(

--- a/postprocessing/PostProcessAdmin.py
+++ b/postprocessing/PostProcessAdmin.py
@@ -85,9 +85,14 @@ class PostProcessAdmin:
         self._process_data(self.data)
         try:
             self.send("/queue/" + self.conf.reduction_started, json.dumps(self.data))
+            # get instrument shared directory
             instrument_shared_dir = os.path.join(
                 "/", self.facility, self.instrument, "shared", "autoreduce"
             )
+            if len(self.conf.dev_instrument_shared) > 0:
+                instrument_shared_dir = self.conf.dev_instrument_shared
+
+            # get the proposal shared directory
             proposal_shared_dir = os.path.join(
                 "/",
                 self.facility,
@@ -96,9 +101,8 @@ class PostProcessAdmin:
                 "shared",
                 "autoreduce",
             )
-
             # Allow for an alternate output directory, if defined
-            if len(self.conf.dev_output_dir.strip()) > 0:
+            if len(self.conf.dev_output_dir) > 0:
                 proposal_shared_dir = self.conf.dev_output_dir
             logging.info("Using output directory: %s" % proposal_shared_dir)
 

--- a/tests/unit/postprocessing/test_PostProcessAdmin.py
+++ b/tests/unit/postprocessing/test_PostProcessAdmin.py
@@ -1,0 +1,76 @@
+from __future__ import print_function
+
+import shutil
+
+from postprocessing.Configuration import Configuration
+from postprocessing.PostProcessAdmin import PostProcessAdmin
+
+# third-party imports
+import os
+import pytest
+import tempfile
+
+
+def getDevConfiguration(dev_output_dir=""):
+    """
+    Create a Configuration object with a now developer directory
+    @param dev_output_dir: Location of the output directory
+    """
+    srcdir = os.path.dirname(os.path.realpath(__file__))  # directory this file is in
+    # go up 3 levels
+    for i in range(3):
+        srcdir = os.path.split(srcdir)[0]
+    # load the developer configuration file
+    config = Configuration(
+        os.path.join(srcdir, "configuration/post_process_consumer.conf.development")
+    )
+    if dev_output_dir:
+        config.dev_output_dir = dev_output_dir
+    return config
+
+
+def test_bad_constructor():
+    # require that it fails if nothing is provided
+    with pytest.raises(TypeError):
+        _ = PostProcessAdmin()
+
+
+def test_good_constructor(mocker):
+    # setup mock configuration
+    outdir = tempfile.mkdtemp()
+    configuration = getDevConfiguration(outdir)
+
+    # create empty datafile because the processor checks the file exists
+    pretend_datafile = tempfile.mkstemp()[1]  # the name of the file
+    assert os.path.exists(pretend_datafile)
+
+    # data examples are taken from PostProcessing.py
+    data = {
+        "information": "mac83808.sns.gov",
+        "run_number": "30892",
+        "instrument": "EQSANS",
+        "ipts": "IPTS-10674",
+        "facility": "SNS",
+        "data_file": pretend_datafile,
+    }  # "/Volumes/RAID/SNS/EQSANS/IPTS-10674/0/30892/NeXus/EQSANS_30892_event.nxs"}
+    postProc = PostProcessAdmin(data, configuration)
+    assert postProc
+
+    # mock the send method so it doesn't try to actually send messages to activemq
+    postProc.send = mocker.MagicMock()
+
+    # run reduction
+    postProc.reduce()
+    # verify reduction log directory - this should only be a single subdirectory
+    outdir_contents = [os.path.join(outdir, item) for item in os.listdir(outdir)]
+    assert outdir_contents == [os.path.join(outdir, "reduction_log")]
+
+    # cleanup
+    os.unlink(pretend_datafile)
+    shutil.rmtree(outdir)
+
+    # create_reduction_script() delegates to other functions
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
This adds unit tests for the `PostProcessAdmin` and makes some changes to `Configuration` to support that. The `__main__` function is not currently covered because it requires mocking more of the stompest functionality.

[coverity report](https://app.codecov.io/github/neutrons/post_processing_agent/pull/24/blob/postprocessing/PostProcessAdmin.py)

This is part of [EWM2814](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2814).