### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -34,6 +34,36 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  integration-tests:
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Set up MicroMamba
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: environment.yml
+        condarc: |
+          channels:
+            - conda-forge
+            - default
+        cache-environment: true
+
+    - name: start docker containers
+      run: docker-compose -f tests/integration/docker-compose.yml up --build -d
+
+    - name: sleep to wait for containers to start up
+      run: sleep 2
+
+    - name: Run integration tests
+      shell: bash -l {0}
+      run: python -m pytest tests/integration
+
+    - name: stop docker containers
+      run: docker-compose -f tests/integration/docker-compose.yml down
+
   rpm:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,20 @@ This is one of the ways [pytest allows for selecting tests](https://docs.pytest.
 Specifying a directory or file will run all tests within that directory (recursively) or file.
 Specifying a regular expression using ``-k`` will select all tests that match the regular expression independent of where they are defined
 
+### Integration tests
+
+The integration tests requires activemq and the queueprocessor to be running, they will be automatically skipped if activemq is not running. This can be achieved using the docker-compose file provided,
+
+    docker-compose -f tests/integration/docker-compose.yml up -d --build
+
+then run
+
+    python -m pytest tests/integration
+
+after which you can stop docker with
+
+    docker-compose -f tests/integration/docker-compose.yml down
+
 
 Running manual tests for mantidpython.py
 ----------------------------------------

--- a/configuration/post_process_consumer.conf.local
+++ b/configuration/post_process_consumer.conf.local
@@ -15,6 +15,7 @@
     "reduction_complete": "REDUCTION.COMPLETE",
     "reduction_error": "REDUCTION.ERROR",
     "reduction_disabled": "REDUCTION.DISABLED",
+    "create_reduction_script": "REDUCTION.CREATE_SCRIPT",
     "heart_beat": "/topic/SNS.COMMON.STATUS.AUTOREDUCE.0",
     "dev_output_dir": "",
     "reduction_data_ready": "REDUCTION.DATA_READY",

--- a/configuration/post_process_consumer.conf.local
+++ b/configuration/post_process_consumer.conf.local
@@ -21,5 +21,6 @@
     "reduction_data_ready": "REDUCTION.DATA_READY",
     "communication_only": 0,
     "max_procs": 10,
-    "exceptions": ["Error in logging framework", "Found no integrated charge value in gd_prtn_chrg"]
+    "exceptions": ["Error in logging framework", "Found no integrated charge value in gd_prtn_chrg"],
+    "processors": ["oncat_processor.ONCatProcessor"]
 }

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,8 @@ dependencies:
   - pytest-cov
   - pytest-mock
   - pip: # will need to be installed separately if pip is broken
+    - twisted==12.2.0
     - stompest==2.1.6
+    - stompest-async==2.1.6
 # needed for wheel - add when switching to python3
 #  - build

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - python=2.7
   - pip<21.0
   # if pip doesn't work https://stackoverflow.com/questions/49940813/pip-no-module-named-internal
+  - gcc_linux-64
   - pytest
   - pytest-cov
   - pytest-mock

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -7,32 +7,31 @@ COPY environment.yml .
 
 RUN conda env create
 
-RUN mkdir -p /opt/postprocessing/log
-
 COPY postprocessing /opt/postprocessing/postprocessing
 COPY configuration/post_process_consumer.conf.local /etc/autoreduce/post_processing.conf
 RUN sed -i 's/localhost/activemq/' /etc/autoreduce/post_processing.conf
 
-RUN mkdir -p /opt/postprocessing/scripts
-RUN touch /opt/postprocessing/scripts/oncat_ingest.py
-
 ENV PYTHONPATH /opt/postprocessing
 
-RUN mkdir -p /SNS/EQSANS/IPTS-10674/0/30892/NeXus
-RUN mkdir -p /SNS/EQSANS/IPTS-10674/shared/autoreduce
-RUN touch /SNS/EQSANS/IPTS-10674/0/30892/NeXus/EQSANS_30892_event.nxs
-RUN mkdir -p /SNS/EQSANS/shared/autoreduce
-RUN echo "import sys;print(sys.argv[1:])" > /SNS/EQSANS/shared/autoreduce/reduce_EQSANS.py
-
-RUN mkdir -p /SNS/CORELLI/IPTS-15526/nexus
-RUN touch /SNS/CORELLI/IPTS-15526/nexus/CORELLI_29666.nxs.h5
-RUN mkdir -p /SNS/CORELLI/shared/autoreduce
-RUN echo "raise RuntimeError('This is an ERROR!')" > /SNS/CORELLI/shared/autoreduce/reduce_CORELLI.py
-
-RUN mkdir -p /SNS/TOPAZ/shared/autoreduce
-RUN echo "a=0" > /SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ.py
-RUN echo "a=1" > /SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ_default.py
-RUN echo "a=\${value}" > /SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ.py.template
+RUN mkdir -p /opt/postprocessing/log && \
+    mkdir -p /opt/postprocessing/scripts && \
+    touch /opt/postprocessing/scripts/oncat_ingest.py && \
+    \
+    mkdir -p /SNS/EQSANS/IPTS-10674/0/30892/NeXus && \
+    mkdir -p /SNS/EQSANS/IPTS-10674/shared/autoreduce && \
+    touch /SNS/EQSANS/IPTS-10674/0/30892/NeXus/EQSANS_30892_event.nxs && \
+    mkdir -p /SNS/EQSANS/shared/autoreduce && \
+    echo "import sys;print(sys.argv[1:])" > /SNS/EQSANS/shared/autoreduce/reduce_EQSANS.py && \
+    \
+    mkdir -p /SNS/CORELLI/IPTS-15526/nexus && \
+    touch /SNS/CORELLI/IPTS-15526/nexus/CORELLI_29666.nxs.h5 && \
+    mkdir -p /SNS/CORELLI/shared/autoreduce && \
+    echo "raise RuntimeError('This is an ERROR!')" > /SNS/CORELLI/shared/autoreduce/reduce_CORELLI.py && \
+    \
+    mkdir -p /SNS/TOPAZ/shared/autoreduce && \
+    echo "a=0" > /SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ.py && \
+    echo "a=1" > /SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ_default.py && \
+    echo "a=\${value}" > /SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ.py.template
 
 RUN echo "#!/bin/bash" > /usr/bin/run_postprocessing && \
     echo ". activate post_processing_agent_py2" >> /usr/bin/run_postprocessing && \

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,18 +1,17 @@
-FROM condaforge/mambaforge
+FROM mambaorg/micromamba
 
-RUN apt-get update -y
-RUN apt-get install gcc -y
+COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml .
 
-COPY environment.yml .
+RUN micromamba install --yes -n base --file environment.yml
 
-RUN conda env create
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
-COPY postprocessing /opt/postprocessing/postprocessing
-COPY configuration/post_process_consumer.conf.local /etc/autoreduce/post_processing.conf
-RUN sed -i 's/localhost/activemq/' /etc/autoreduce/post_processing.conf
+COPY --chown=$MAMBA_USER:$MAMBA_USER postprocessing /opt/postprocessing/postprocessing
+COPY --chown=$MAMBA_USER:$MAMBA_USER tests/integration/post_processing.conf /etc/autoreduce/post_processing.conf
 
 ENV PYTHONPATH /opt/postprocessing
 
+USER root
 RUN mkdir -p /opt/postprocessing/log && \
     mkdir -p /opt/postprocessing/scripts && \
     touch /opt/postprocessing/scripts/oncat_ingest.py && \
@@ -31,11 +30,10 @@ RUN mkdir -p /opt/postprocessing/log && \
     mkdir -p /SNS/TOPAZ/shared/autoreduce && \
     echo "a=0" > /SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ.py && \
     echo "a=1" > /SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ_default.py && \
-    echo "a=\${value}" > /SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ.py.template
+    echo "a=\${value}" > /SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ.py.template && \
+    \
+    chown -R $MAMBA_USER:$MAMBA_USER /opt/postprocessing /SNS
 
-RUN echo "#!/bin/bash" > /usr/bin/run_postprocessing && \
-    echo ". activate post_processing_agent_py2" >> /usr/bin/run_postprocessing && \
-    echo "/opt/postprocessing/postprocessing/queueProcessor.py" >> /usr/bin/run_postprocessing && \
-    chmod +x /usr/bin/run_postprocessing
+USER $MAMBA_USER
 
-CMD /usr/bin/run_postprocessing
+CMD /opt/postprocessing/postprocessing/queueProcessor.py

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -13,9 +13,13 @@ COPY postprocessing /opt/postprocessing/postprocessing
 COPY configuration/post_process_consumer.conf.local /etc/autoreduce/post_processing.conf
 RUN sed -i 's/localhost/activemq/' /etc/autoreduce/post_processing.conf
 
+RUN mkdir -p /opt/postprocessing/scripts
+RUN touch /opt/postprocessing/scripts/oncat_ingest.py
+
 ENV PYTHONPATH /opt/postprocessing
 
 RUN mkdir -p /SNS/EQSANS/IPTS-10674/0/30892/NeXus
+RUN mkdir -p /SNS/EQSANS/IPTS-10674/shared/autoreduce
 RUN touch /SNS/EQSANS/IPTS-10674/0/30892/NeXus/EQSANS_30892_event.nxs
 RUN mkdir -p /SNS/EQSANS/shared/autoreduce
 RUN echo "import sys;print(sys.argv[1:])" > /SNS/EQSANS/shared/autoreduce/reduce_EQSANS.py

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -25,6 +25,11 @@ RUN touch /SNS/CORELLI/IPTS-15526/nexus/CORELLI_29666.nxs.h5
 RUN mkdir -p /SNS/CORELLI/shared/autoreduce
 RUN echo "raise RuntimeError('This is an ERROR!')" > /SNS/CORELLI/shared/autoreduce/reduce_CORELLI.py
 
+RUN mkdir -p /SNS/TOPAZ/shared/autoreduce
+RUN echo "a=0" > /SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ.py
+RUN echo "a=1" > /SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ_default.py
+RUN echo "a=\${value}" > /SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ.py.template
+
 RUN echo "#!/bin/bash" > /usr/bin/run_postprocessing && \
     echo ". activate post_processing_agent_py2" >> /usr/bin/run_postprocessing && \
     echo "/opt/postprocessing/postprocessing/queueProcessor.py" >> /usr/bin/run_postprocessing && \

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,0 +1,33 @@
+FROM condaforge/mambaforge
+
+RUN apt-get update -y
+RUN apt-get install gcc -y
+
+COPY environment.yml .
+
+RUN conda env create
+
+RUN mkdir -p /opt/postprocessing/log
+
+COPY postprocessing /opt/postprocessing/postprocessing
+COPY configuration/post_process_consumer.conf.local /etc/autoreduce/post_processing.conf
+RUN sed -i 's/localhost/activemq/' /etc/autoreduce/post_processing.conf
+
+ENV PYTHONPATH /opt/postprocessing
+
+RUN mkdir -p /SNS/EQSANS/IPTS-10674/0/30892/NeXus
+RUN touch /SNS/EQSANS/IPTS-10674/0/30892/NeXus/EQSANS_30892_event.nxs
+RUN mkdir -p /SNS/EQSANS/shared/autoreduce
+RUN echo "import sys;print(sys.argv[1:])" > /SNS/EQSANS/shared/autoreduce/reduce_EQSANS.py
+
+RUN mkdir -p /SNS/CORELLI/IPTS-15526/nexus
+RUN touch /SNS/CORELLI/IPTS-15526/nexus/CORELLI_29666.nxs.h5
+RUN mkdir -p /SNS/CORELLI/shared/autoreduce
+RUN echo "raise RuntimeError('This is an ERROR!')" > /SNS/CORELLI/shared/autoreduce/reduce_CORELLI.py
+
+RUN echo "#!/bin/bash" > /usr/bin/run_postprocessing && \
+    echo ". activate post_processing_agent_py2" >> /usr/bin/run_postprocessing && \
+    echo "/opt/postprocessing/postprocessing/queueProcessor.py" >> /usr/bin/run_postprocessing && \
+    chmod +x /usr/bin/run_postprocessing
+
+CMD /usr/bin/run_postprocessing

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+
+  post_processing_agent:
+    build:
+      context: ../..
+      dockerfile: ./tests/integration/Dockerfile
+
+  activemq:
+    image: rmohr/activemq
+    hostname: activemq
+    ports:
+      - 8161:8161
+      - 61613:61613

--- a/tests/integration/post_processing.conf
+++ b/tests/integration/post_processing.conf
@@ -1,5 +1,5 @@
 {
-    "failover_uri": "failover:(tcp://localhost:61613)?randomize=false,startupMaxReconnectAttempts=100,initialReconnectDelay=1000,maxReconnectDelay=5000,maxReconnectAttempts=-1",
+    "failover_uri": "failover:(tcp://activemq:61613)?randomize=false,startupMaxReconnectAttempts=100,initialReconnectDelay=1000,maxReconnectDelay=5000,maxReconnectAttempts=-1",
     "amq_queues": ["/queue/REDUCTION.CREATE_SCRIPT", "/queue/REDUCTION.DATA_READY", "/queue/CATALOG.DATA_READY", "/queue/REDUCTION_CATALOG.DATA_READY"],
     "amq_user": "",
     "amq_pwd": "",
@@ -15,10 +15,12 @@
     "reduction_complete": "REDUCTION.COMPLETE",
     "reduction_error": "REDUCTION.ERROR",
     "reduction_disabled": "REDUCTION.DISABLED",
+    "create_reduction_script": "REDUCTION.CREATE_SCRIPT",
     "heart_beat": "/topic/SNS.COMMON.STATUS.AUTOREDUCE.0",
     "dev_output_dir": "",
     "reduction_data_ready": "REDUCTION.DATA_READY",
     "communication_only": 0,
     "max_procs": 10,
-    "exceptions": ["Error in logging framework", "Found no integrated charge value in gd_prtn_chrg"]
+    "exceptions": ["Error in logging framework", "Found no integrated charge value in gd_prtn_chrg"],
+    "processors": ["oncat_processor.ONCatProcessor"]
 }

--- a/tests/integration/test_cataloging.py
+++ b/tests/integration/test_cataloging.py
@@ -1,0 +1,41 @@
+import json
+import pytest
+
+from stompest.config import StompConfig
+from stompest.sync import Stomp
+from stompest.error import StompConnectTimeout
+
+
+def test_oncat_catalog():
+    """This should just replace reduce_TOPAZ.py with reduce_TOPAZ_default.py"""
+    message = {
+        "run_number": "30892",
+        "instrument": "EQSANS",
+        "ipts": "IPTS-10674",
+        "facility": "SNS",
+        "data_file": "/SNS/EQSANS/IPTS-10674/0/30892/NeXus/EQSANS_30892_event.nxs",
+    }
+
+    client = Stomp(StompConfig("tcp://localhost:61613"))
+    try:
+        client.connect()
+    except StompConnectTimeout:
+        pytest.skip("Requires activemq running")
+
+    # send data ready
+    client.send("/queue/CATALOG.ONCAT.DATA_READY", json.dumps(message))
+
+    # expect a message on CATALOG.ONCAT.COMPLETE
+    client.subscribe("/queue/CATALOG.ONCAT.COMPLETE")
+
+    assert client.canRead(5)
+    frame = client.receiveFrame()
+
+    client.disconnect()
+
+    msg = json.loads(frame.body)
+    assert msg["run_number"] == message["run_number"]
+    assert msg["instrument"] == message["instrument"]
+    assert msg["ipts"] == message["ipts"]
+    assert msg["facility"] == message["facility"]
+    assert msg["data_file"] == message["data_file"]

--- a/tests/integration/test_create_script.py
+++ b/tests/integration/test_create_script.py
@@ -1,7 +1,7 @@
 import time
 import json
-import subprocess
 import pytest
+from tests.conftest import docker_exec_and_cat
 
 from stompest.config import StompConfig
 from stompest.sync import Stomp
@@ -27,11 +27,7 @@ def test_default():
     time.sleep(1)
 
     # check that reduce_TOPAZ.py is updated correctly
-    reduce_TOPAZ = subprocess.check_output(
-        "docker exec integration_post_processing_agent_1 cat /SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ.py",
-        stderr=subprocess.STDOUT,
-        shell=True,
-    )
+    reduce_TOPAZ = docker_exec_and_cat("/SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ.py")
 
     assert reduce_TOPAZ == "a=1\n"
 
@@ -59,10 +55,6 @@ def test_template():
     time.sleep(1)
 
     # check that reduce_TOPAZ.py is updated correctly
-    reduce_TOPAZ = subprocess.check_output(
-        "docker exec integration_post_processing_agent_1 cat /SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ.py",
-        stderr=subprocess.STDOUT,
-        shell=True,
-    )
+    reduce_TOPAZ = docker_exec_and_cat("/SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ.py")
 
     assert reduce_TOPAZ == "a=42\n"

--- a/tests/integration/test_create_script.py
+++ b/tests/integration/test_create_script.py
@@ -1,0 +1,68 @@
+import time
+import json
+import subprocess
+import pytest
+
+from stompest.config import StompConfig
+from stompest.sync import Stomp
+from stompest.error import StompConnectTimeout
+
+
+def test_default():
+    """This should just replace reduce_TOPAZ.py with reduce_TOPAZ_default.py"""
+
+    message = {"instrument": "TOPAZ", "use_default": True, "template_data": {}}
+
+    client = Stomp(StompConfig("tcp://localhost:61613"))
+    try:
+        client.connect()
+    except StompConnectTimeout:
+        pytest.skip("Requires activemq running")
+
+    # send data ready
+    client.send("/queue/REDUCTION.CREATE_SCRIPT", json.dumps(message))
+
+    client.disconnect()
+
+    time.sleep(1)
+
+    # check that reduce_TOPAZ.py is updated correctly
+    reduce_TOPAZ = subprocess.check_output(
+        "docker exec integration_post_processing_agent_1 cat /SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ.py",
+        stderr=subprocess.STDOUT,
+        shell=True,
+    )
+
+    assert reduce_TOPAZ == "a=1\n"
+
+
+def test_template():
+    """This should just replace reduce_TOPAZ.py with reduce_TOPAZ_default.py"""
+
+    message = {
+        "instrument": "TOPAZ",
+        "use_default": False,
+        "template_data": {"value": 42},
+    }
+
+    client = Stomp(StompConfig("tcp://localhost:61613"))
+    try:
+        client.connect()
+    except StompConnectTimeout:
+        pytest.skip("Requires activemq running")
+
+    # send data ready
+    client.send("/queue/REDUCTION.CREATE_SCRIPT", json.dumps(message))
+
+    client.disconnect()
+
+    time.sleep(1)
+
+    # check that reduce_TOPAZ.py is updated correctly
+    reduce_TOPAZ = subprocess.check_output(
+        "docker exec integration_post_processing_agent_1 cat /SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ.py",
+        stderr=subprocess.STDOUT,
+        shell=True,
+    )
+
+    assert reduce_TOPAZ == "a=42\n"

--- a/tests/integration/test_data_ready.py
+++ b/tests/integration/test_data_ready.py
@@ -1,10 +1,10 @@
 import json
-import subprocess
 import pytest
 
 from stompest.config import StompConfig
 from stompest.sync import Stomp
 from stompest.error import StompConnectTimeout
+from tests.conftest import docker_exec_and_cat
 
 
 def test_missing_data():
@@ -108,10 +108,8 @@ def test_reduction():
     assert msg["data_file"] == message["data_file"]
 
     # we can also check that the reduction did run by checking the reduction_log
-    reduction_log = subprocess.check_output(
-        "docker exec integration_post_processing_agent_1 cat /SNS/EQSANS/IPTS-10674/shared/autoreduce/reduction_log/EQSANS_30892_event.nxs.log",
-        stderr=subprocess.STDOUT,
-        shell=True,
+    reduction_log = docker_exec_and_cat(
+        "/SNS/EQSANS/IPTS-10674/shared/autoreduce/reduction_log/EQSANS_30892_event.nxs.log"
     )
 
     assert (

--- a/tests/integration/test_data_ready.py
+++ b/tests/integration/test_data_ready.py
@@ -1,0 +1,155 @@
+import json
+import subprocess
+import pytest
+
+from stompest.config import StompConfig
+from stompest.sync import Stomp
+from stompest.error import StompConnectTimeout
+
+
+def test_missing_data():
+    message = {
+        "run_number": "30892",
+        "instrument": "EQSANS",
+        "ipts": "IPTS-10674",
+        "facility": "SNS",
+        "data_file": "/SNS/DOES_NOT_EXIST.nxs",
+    }
+
+    client = Stomp(StompConfig("tcp://localhost:61613"))
+    try:
+        client.connect()
+    except StompConnectTimeout:
+        pytest.skip("Requires activemq running")
+
+    # send data ready
+    client.send("/queue/REDUCTION.DATA_READY", json.dumps(message))
+
+    # expect a error for missing file
+    client.subscribe("/queue/POSTPROCESS.ERROR")
+
+    assert client.canRead(5)
+    frame = client.receiveFrame()
+
+    client.disconnect()
+
+    msg = json.loads(frame.body)
+    assert (
+        msg["error"]
+        == "Data file does not exist or is not readable: /SNS/DOES_NOT_EXIST.nxs"
+    )
+
+
+def test_disabled_reduction():
+    message = {
+        "run_number": "30892",
+        "instrument": "INSTRUMENT",
+        "ipts": "IPTS-10674",
+        "facility": "SNS",
+        "data_file": "/SNS/EQSANS/IPTS-10674/0/30892/NeXus/EQSANS_30892_event.nxs",
+    }
+
+    client = Stomp(StompConfig("tcp://localhost:61613"))
+    try:
+        client.connect()
+    except StompConnectTimeout:
+        pytest.skip("Requires activemq running")
+
+    # send data ready
+    client.send("/queue/REDUCTION.DATA_READY", json.dumps(message))
+
+    # expect a reduction disabled
+    client.subscribe("/queue/REDUCTION.DISABLED")
+
+    assert client.canRead(5)
+    frame = client.receiveFrame()
+
+    client.disconnect()
+
+    msg = json.loads(frame.body)
+    assert msg["run_number"] == message["run_number"]
+    assert msg["instrument"] == message["instrument"]
+    assert msg["ipts"] == message["ipts"]
+    assert msg["facility"] == message["facility"]
+    assert msg["data_file"] == message["data_file"]
+
+
+def test_reduction():
+    message = {
+        "run_number": "30892",
+        "instrument": "EQSANS",
+        "ipts": "IPTS-10674",
+        "facility": "SNS",
+        "data_file": "/SNS/EQSANS/IPTS-10674/0/30892/NeXus/EQSANS_30892_event.nxs",
+    }
+
+    client = Stomp(StompConfig("tcp://localhost:61613"))
+    try:
+        client.connect()
+    except StompConnectTimeout:
+        pytest.skip("Requires activemq running")
+
+    # send data ready
+    client.send("/queue/REDUCTION.DATA_READY", json.dumps(message))
+
+    # expect a reduction complete
+    client.subscribe("/queue/REDUCTION.COMPLETE")
+
+    assert client.canRead(5)
+    frame = client.receiveFrame()
+
+    client.disconnect()
+
+    msg = json.loads(frame.body)
+    assert msg["run_number"] == message["run_number"]
+    assert msg["instrument"] == message["instrument"]
+    assert msg["ipts"] == message["ipts"]
+    assert msg["facility"] == message["facility"]
+    assert msg["data_file"] == message["data_file"]
+
+    # we can also check that the reduction did run by checking the reduction_log
+    reduction_log = subprocess.check_output(
+        "docker exec integration_post_processing_agent_1 cat /SNS/EQSANS/IPTS-10674/shared/autoreduce/reduction_log/EQSANS_30892_event.nxs.log",
+        stderr=subprocess.STDOUT,
+        shell=True,
+    )
+
+    assert (
+        reduction_log
+        == "['/SNS/EQSANS/IPTS-10674/0/30892/NeXus/EQSANS_30892_event.nxs', '/SNS/EQSANS/IPTS-10674/shared/autoreduce/']\n"
+    )
+
+
+def test_reduction_error():
+    message = {
+        "run_number": "29666",
+        "instrument": "CORELLI",
+        "ipts": "IPTS-15526",
+        "facility": "SNS",
+        "data_file": "/SNS/CORELLI/IPTS-15526/nexus/CORELLI_29666.nxs.h5",
+    }
+
+    client = Stomp(StompConfig("tcp://localhost:61613"))
+    try:
+        client.connect()
+    except StompConnectTimeout:
+        pytest.skip("Requires activemq running")
+
+    # send data ready
+    client.send("/queue/REDUCTION.DATA_READY", json.dumps(message))
+
+    # expect a reduction error
+    client.subscribe("/queue/REDUCTION.ERROR")
+
+    assert client.canRead(5)
+    frame = client.receiveFrame()
+
+    client.disconnect()
+
+    msg = json.loads(frame.body)
+    assert msg["run_number"] == message["run_number"]
+    assert msg["instrument"] == message["instrument"]
+    assert msg["ipts"] == message["ipts"]
+    assert msg["facility"] == message["facility"]
+    assert msg["data_file"] == message["data_file"]
+    assert msg["error"] == "REDUCTION: This is an ERROR!"


### PR DESCRIPTION
Ref [2975](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=2975&tab=com.ibm.team.workitem.tab.links)

Follow the instructions in the README.md to run the integration tests.

ActiveMQ and the post-processing agent are running in docker containers. There are a lot of things hard-coded to `/SNS/...etc` so having it in a docker container makes it easy to fake the filesystem.

These tests do not interact directly with the post-processor but via sending and receiving messages through the ActiveMQ message broker.