### PR TITLE
Move from stompest to stomp.py and to python 3.9

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -86,23 +86,24 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  rpm:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v2
-
-    - name: Build RPM inside Docker
-      run: |
-        docker build --tag postprocess --target=package -f Dockerfile .
-        fname=`docker run -v $(pwd):/store postprocess ls /root/rpmbuild/RPMS/noarch`
-        docker run -v `pwd`:/store postprocess mv /root/rpmbuild/RPMS/noarch/$fname /store
-        one=${fname#*postprocessing-}
-        two=${one%.noarch*}
-        echo "::set-output name=version::$two"
-        echo "::set-output name=fname::$fname"
-      continue-on-error: false
+# disable until spec file is updated to python 3
+#  rpm:
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#    - name: Checkout Repository
+#      uses: actions/checkout@v2
+#
+#    - name: Build RPM inside Docker
+#      run: |
+#        docker build --tag postprocess --target=package -f Dockerfile .
+#        fname=`docker run -v $(pwd):/store postprocess ls /root/rpmbuild/RPMS/noarch`
+#        docker run -v `pwd`:/store postprocess mv /root/rpmbuild/RPMS/noarch/$fname /store
+#        one=${fname#*postprocessing-}
+#        two=${one%.noarch*}
+#        echo "::set-output name=version::$two"
+#        echo "::set-output name=fname::$fname"
+#      continue-on-error: false
 
 # TODO: uncomment this once we have switched to python3 and can conda install the module build
 #  wheel:

--- a/configuration/post_process_consumer.conf.development
+++ b/configuration/post_process_consumer.conf.development
@@ -1,5 +1,6 @@
 {
     "failover_uri": "failover:(tcp://localhost:61613)?randomize=false,startupMaxReconnectAttempts=100,initialReconnectDelay=1000,maxReconnectDelay=5000,maxReconnectAttempts=-1",
+    "brokers": [["localhost", 61613]],
     "amq_queues": ["/queue/REDUCTION.DATA_READY"],
     "amq_user": "icat",
     "amq_pwd": "icat",

--- a/configuration/post_process_consumer.conf.local
+++ b/configuration/post_process_consumer.conf.local
@@ -1,5 +1,6 @@
 {
     "failover_uri": "failover:(tcp://localhost:61613)?randomize=false,startupMaxReconnectAttempts=100,initialReconnectDelay=1000,maxReconnectDelay=5000,maxReconnectAttempts=-1",
+    "brokers": [("localhost", 61613)],
     "amq_queues": ["/queue/REDUCTION.CREATE_SCRIPT", "/queue/REDUCTION.DATA_READY", "/queue/CATALOG.DATA_READY", "/queue/REDUCTION_CATALOG.DATA_READY"],
     "amq_user": "",
     "amq_pwd": "",

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - pytest-cov
   - pytest-mock
   - requests
+  - stomp.py=7
   - twisted
   - pip: # will need to be installed separately if pip is broken
     - stompest

--- a/environment.yml
+++ b/environment.yml
@@ -3,14 +3,13 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.6
-  - pip
+  - python=3.9
   - plotly
   - pre-commit
   - pytest
   - pytest-cov
   - pytest-mock
-  - requests
+  - requests=2.25
   - stomp.py=7
 # needed for wheel - add when switching to python3
 #  - build

--- a/environment.yml
+++ b/environment.yml
@@ -12,9 +12,5 @@ dependencies:
   - pytest-mock
   - requests
   - stomp.py=7
-  - twisted
-  - pip: # will need to be installed separately if pip is broken
-    - stompest
-    - stompest-async
 # needed for wheel - add when switching to python3
 #  - build

--- a/postprocessing/Configuration.py
+++ b/postprocessing/Configuration.py
@@ -34,6 +34,7 @@ class Configuration(object):
         self.amq_pwd = config["amq_pwd"]
         # ActiveMQ broker information
         self.failover_uri = config["failover_uri"]
+        self.brokers = [(host, port) for host, port in config["brokers"]]
         self.queues = config["amq_queues"]
         self.sw_dir = config["sw_dir"] if "sw_dir" in config else "/opt/postprocessing"
         self.postprocess_error = config["postprocess_error"]

--- a/postprocessing/Configuration.py
+++ b/postprocessing/Configuration.py
@@ -13,7 +13,7 @@ import logging
 import importlib
 
 
-class Configuration(object):
+class Configuration:
     """
     Read and process configuration file and provide an easy way to create a configured Client object
     """
@@ -21,10 +21,10 @@ class Configuration(object):
     def __init__(self, config_file):
         if os.access(config_file, os.R_OK) is False:
             raise RuntimeError(
-                "Configuration file doesn't exist or is not readable: %s" % config_file
+                f"Configuration file doesn't exist or is not readable: {config_file}"
             )
-        cfg = open(config_file, "r")
-        json_encoded = cfg.read()
+        with open(config_file, "r") as cfg:
+            json_encoded = cfg.read()
         config = json.loads(json_encoded)
 
         # Keep a record of which config file we are using
@@ -140,10 +140,10 @@ class Configuration(object):
                 if len(toks) == 2:
                     # for instance, emulate `from oncat_processor import ONCatProcessor`
                     processor_module = importlib.import_module(  # noqa: F841
-                        "postprocessing.processors.%s" % toks[0]
+                        f"postprocessing.processors.{toks[0]}"
                     )
                     try:
-                        processor_class = eval("processor_module.%s" % toks[1])
+                        processor_class = eval(f"processor_module.{toks[1]}")
                         self.queues.append(processor_class.get_input_queue_name())
                     except:  # noqa: E722
                         logging.error(
@@ -173,7 +173,7 @@ class Configuration(object):
         logger.info("  - Error exceptions: %s", str(self.exceptions))
 
 
-class StreamToLogger(object):
+class StreamToLogger:
     r"""File-like stream object that redirects writes to a Logger instance."""
 
     def __init__(self, logger, log_level=logging.INFO):
@@ -252,8 +252,7 @@ def read_configuration(
                 break
         else:
             raise RuntimeError(
-                "Default configuration file(s) do not exist, or unreadable: %s"
-                % str(defaults)
+                f"Default configuration file(s) do not exist, or unreadable: {defaults}"
             )
 
     configuration = Configuration(config_file)

--- a/postprocessing/Configuration.py
+++ b/postprocessing/Configuration.py
@@ -173,11 +173,6 @@ class Configuration(object):
         logger.info("  - Error exceptions: %s", str(self.exceptions))
 
 
-# Set the log level for the Stomp client
-stomp_logger = logging.getLogger("stompest.sync.client")
-stomp_logger.setLevel(logging.ERROR)
-
-
 class StreamToLogger(object):
     r"""File-like stream object that redirects writes to a Logger instance."""
 

--- a/postprocessing/Configuration.py
+++ b/postprocessing/Configuration.py
@@ -94,7 +94,7 @@ class Configuration:
             config["dev_output_dir"].strip() if "dev_output_dir" in config else ""
         )
         self.python_executable = (
-            config["python_exec"] if "python_exec" in config else "python"
+            config["python_exec"] if "python_exec" in config else "python3"
         )
 
         self.max_procs = config["max_procs"] if "max_procs" in config else 5

--- a/postprocessing/Consumer.py
+++ b/postprocessing/Consumer.py
@@ -80,7 +80,7 @@ class Listener(stomp.ConnectionListener):
                 else:
                     self.instrument_jobs[instrument] = []
             self.conn.ack(frame.headers["message-id"], frame.headers["subscription"])
-        except:
+        except:  # noqa: E722
             logging.error(sys.exc_info()[1])
             # Raising an exception here may result in an ActiveMQ result being sent.
             # We therefore pick a message that will mean someone to the users.
@@ -130,7 +130,7 @@ class Listener(stomp.ConnectionListener):
                     "Resuming. Number of sub-processes: %s", len(self.procList)
                 )
             self.update_processes()
-        except:
+        except:  # noqa: E722
             logging.error(sys.exc_info()[1])
             # Raising an exception here may result in an ActiveMQ result being sent.
             # We therefore pick a message that will mean someone to the users.
@@ -181,7 +181,7 @@ def heartbeat(conn, destination, data_dict={}):
             }
         )
         conn.send(destination, json.dumps(data_dict).encode())
-    except:
+    except:  # noqa: E722
         logging.error("Could not send heartbeat: %s" % sys.exc_info()[1])
 
 
@@ -261,10 +261,10 @@ class Consumer:
                     if time.time() - last_heartbeat > HEARTBEAT_DELAY:
                         last_heartbeat = time.time()
                         heartbeat(self._connection, self.config.heart_beat)
-                except:
+                except:  # noqa: E722
                     logging.exception("Problem writing heartbeat")
 
                 time.sleep(waiting_period)
-            except:
+            except:  # noqa: E722
                 logging.exception("Problem connecting to AMQ broker")
                 time.sleep(5.0)

--- a/postprocessing/Consumer.py
+++ b/postprocessing/Consumer.py
@@ -5,7 +5,12 @@ The original code for this class was take from https://github.com/mantidproject/
 
 @copyright: 2014 Oak Ridge National Laboratory
 """
-import json, logging, time, subprocess, sys, socket
+import json
+import logging
+import time
+import subprocess
+import sys
+import socket
 import os
 import stomp
 
@@ -158,7 +163,7 @@ class Listener(stomp.ConnectionListener):
         if "reply_to" in data:
             heartbeat(self.conn, data["reply_to"], data)
         else:
-            logging.error("Incomplete ping request %s" % str(data))
+            logging.error("Incomplete ping request %s", str(data))
 
 
 def heartbeat(conn, destination, data_dict={}):
@@ -182,7 +187,7 @@ def heartbeat(conn, destination, data_dict={}):
         )
         conn.send(destination, json.dumps(data_dict).encode())
     except:  # noqa: E722
-        logging.error("Could not send heartbeat: %s" % sys.exc_info()[1])
+        logging.error("Could not send heartbeat: %s", sys.exc_info()[1])
 
 
 class Consumer:
@@ -195,14 +200,6 @@ class Consumer:
         self.procList = []
         self.instrument_jobs = {}
         self._connection = None
-
-    def set_listener(self, listener):
-        """
-        Set the listener object that will process each incoming message.
-
-        :param listener: listener object
-        """
-        self._listener = listener
 
     def get_connection(self, listener=None):
         """

--- a/postprocessing/Consumer.py
+++ b/postprocessing/Consumer.py
@@ -7,64 +7,20 @@ The original code for this class was take from https://github.com/mantidproject/
 """
 import json, logging, time, subprocess, sys, socket
 import os
+import stomp
 
-from twisted.internet import reactor, defer
-from stompest import async, sync  # noqa: E999
-from stompest.config import StompConfig
-from stompest.async.listener import SubscriptionListener
-from stompest.protocol import StompSpec, StompFailoverUri
+HEARTBEAT_DELAY = 30
 
 
-class Consumer(object):
-    """
-    ActiveMQ consumer
-    """
-
-    def __init__(self, config):
-        self.stompConfig = StompConfig(
-            config.failover_uri,
-            config.amq_user,
-            config.amq_pwd,
-            version=StompSpec.VERSION_1_1,
-        )
+class Listener(stomp.ConnectionListener):
+    def __init__(self, config, connection):
+        super().__init__()
         self.config = config
+        self.conn = connection
         self.procList = []
         self.instrument_jobs = {}
 
-    @defer.inlineCallbacks
-    def run(self):
-        """
-        Run method to start listening
-        """
-        client = async.Stomp(self.stompConfig)
-        yield client.connect()
-        headers = {
-            # client-individual mode is necessary for concurrent processing
-            # (requires ActiveMQ >= 5.2)
-            StompSpec.ACK_HEADER: StompSpec.ACK_CLIENT_INDIVIDUAL,
-            # the maximal number of messages the broker will let you work on at the same time
-            "activemq.prefetchSize": "1",
-        }
-        if self.config.heartbeat_ping not in self.config.queues:
-            self.config.queues.append(self.config.heartbeat_ping)
-        for q in self.config.queues:
-            headers[StompSpec.ID_HEADER] = "post-proc-service-%s" % q
-            client.subscribe(
-                q,
-                headers,
-                listener=SubscriptionListener(
-                    self.consume,
-                    ack=False,
-                    errorDestination=self.config.postprocess_error,
-                ),
-            )
-        try:
-            client = yield client.disconnected
-        except:
-            logging.error("Connection error: %s" % sys.exc_info()[1])
-        reactor.callLater(5, self.run)
-
-    def consume(self, client, frame):
+    def on_message(self, frame):
         """
         Consume an AMQ message.
 
@@ -98,9 +54,11 @@ class Consumer(object):
             # If we received a ping request, just ack
             if self.config.heartbeat_ping in destination:
                 self.ack_ping(data_dict)
-                client.ack(frame)
+                self.conn.ack(
+                    frame.headers["message-id"], frame.headers["subscription"]
+                )
                 return
-            logging.info("Received %s: %s" % (destination, data))
+            logging.info("Received %s: %s", destination, data)
             instrument = None
             if self.config.jobs_per_instrument > 0 and "instrument" in data_dict:
                 instrument = data_dict["instrument"].upper()
@@ -110,15 +68,18 @@ class Consumer(object):
                         len(self.instrument_jobs[instrument])
                         >= self.config.jobs_per_instrument
                     ):
-                        client.nack(frame)
+                        self.conn.nack(
+                            frame.headers["message-id"], frame.headers["subscription"]
+                        )
                         logging.error(
-                            "Too many jobs for %s on %s: rejecting"
-                            % (instrument, os.getpid())
+                            "Too many jobs for %s on %s: rejecting",
+                            instrument,
+                            os.getpid(),
                         )
                         return
                 else:
                     self.instrument_jobs[instrument] = []
-            client.ack(frame)
+            self.conn.ack(frame.headers["message-id"], frame.headers["subscription"])
         except:
             logging.error(sys.exc_info()[1])
             # Raising an exception here may result in an ActiveMQ result being sent.
@@ -142,9 +103,9 @@ class Consumer(object):
             # Format the data argument
             if self.config.task_script_data_arg is not None:
                 command_args.append(self.config.task_script_data_arg)
-            command_args.append(str(data.decode()).replace(" ", ""))
+            command_args.append(str(data).replace(" ", ""))
 
-            logging.warning("Command: %s" % str(command_args))
+            logging.warning("Command: %s", str(command_args))
             proc = subprocess.Popen(command_args)
             logging.warning("end")
             self.procList.append(proc)
@@ -155,7 +116,7 @@ class Consumer(object):
             max_procs_reached = len(self.procList) > self.config.max_procs
             if max_procs_reached:
                 logging.info(
-                    "Maxmimum number of sub-processes reached: %s" % len(self.procList)
+                    "Maxmimum number of sub-processes reached: %s", len(self.procList)
                 )
 
             # If we have reached the max number of processes, block until we have
@@ -166,7 +127,7 @@ class Consumer(object):
 
             if max_procs_reached:
                 logging.info(
-                    "Resuming. Number of sub-processes: %s" % len(self.procList)
+                    "Resuming. Number of sub-processes: %s", len(self.procList)
                 )
             self.update_processes()
         except:
@@ -189,39 +150,121 @@ class Consumer(object):
                         self.instrument_jobs[instrument].remove(i)
                 self.procList.remove(i)
 
-    def heartbeat(self, destination=None, data_dict={}):
-        """
-        Send heartbeats at a regular time interval
-        @param: destination where to send the heartbeat
-        @param data_dict: optional dictionary to pass along
-        """
-        try:
-            if destination is None:
-                destination = self.config.heart_beat
-            stomp = sync.Stomp(self.stompConfig)
-            stomp.connect()
-            if not type(data_dict) == dict:
-                logging.error("Heartbeat argument data_dict was not a dict")
-                data_dict = {}
-            data_dict.update(
-                {
-                    "src_name": socket.gethostname(),
-                    "role": "postprocessing",
-                    "status": "0",
-                    "pid": str(os.getpid()),
-                }
-            )
-            stomp.send(destination, json.dumps(data_dict).encode())
-            stomp.disconnect()
-        except:
-            logging.error("Could not send heartbeat: %s" % sys.exc_info()[1])
-
     def ack_ping(self, data):
         """
         Send an ACK message in response to a ping
         @param data: data that was received with the ping request
         """
         if "reply_to" in data:
-            self.heartbeat(data["reply_to"], data)
+            heartbeat(self.conn, data["reply_to"], data)
         else:
             logging.error("Incomplete ping request %s" % str(data))
+
+
+def heartbeat(conn, destination, data_dict={}):
+    """
+    Send heartbeats at a regular time interval
+    @param: destination where to send the heartbeat
+    @param data_dict: optional dictionary to pass along
+    """
+
+    try:
+        if not isinstance(data_dict, dict):
+            logging.error("Heartbeat argument data_dict was not a dict")
+            data_dict = {}
+        data_dict.update(
+            {
+                "src_name": socket.gethostname(),
+                "role": "postprocessing",
+                "status": "0",
+                "pid": str(os.getpid()),
+            }
+        )
+        conn.send(destination, json.dumps(data_dict).encode())
+    except:
+        logging.error("Could not send heartbeat: %s" % sys.exc_info()[1])
+
+
+class Consumer:
+    """
+    ActiveMQ consumer
+    """
+
+    def __init__(self, config):
+        self.config = config
+        self.procList = []
+        self.instrument_jobs = {}
+        self._connection = None
+
+    def set_listener(self, listener):
+        """
+        Set the listener object that will process each incoming message.
+
+        :param listener: listener object
+        """
+        self._listener = listener
+
+    def get_connection(self, listener=None):
+        """
+        Establish and return a connection to ActiveMQ
+
+        :param listener: listener object
+        """
+        conn = stomp.Connection(host_and_ports=self.config.brokers, keepalive=True)
+
+        listener = Listener(self.config, conn)
+
+        conn.set_listener("postprocessing", listener)
+        conn.connect(self.config.amq_user, self.config.amq_pwd, wait=True)
+
+        time.sleep(0.5)
+        return conn
+
+    def connect(self):
+        """
+        Connect to a broker
+        """
+        if self._connection is None or not self._connection.is_connected():
+            self._disconnect()
+            self._connection = self.get_connection()
+
+            if self.config.heartbeat_ping not in self.config.queues:
+                self.config.queues.append(self.config.heartbeat_ping)
+
+        for q in self.config.queues:
+            self._connection.subscribe(destination=q, id=q, ack="client")
+
+    def _disconnect(self):
+        """
+        Clean disconnect
+        """
+        if self._connection is not None and self._connection.is_connected():
+            self._connection.disconnect()
+        self._connection = None
+
+    def listen_and_wait(self, waiting_period=1.0):
+        """
+        Listen for the next message from the brokers.
+        This method will simply return once the connection is
+        terminated.
+
+        :param waiting_period: sleep time between connection to a broker
+        """
+
+        last_heartbeat = 0
+        while True:
+            try:
+                if self._connection is None or self._connection.is_connected() is False:
+                    self.connect()
+
+                try:
+                    if time.time() - last_heartbeat > HEARTBEAT_DELAY:
+                        last_heartbeat = time.time()
+                        heartbeat(self._connection, self.config.heart_beat)
+                except:
+                    logging.exception("Problem writing heartbeat")
+
+                time.sleep(waiting_period)
+            except:
+                logging.exception("Problem connecting to AMQ broker")
+                time.sleep(5.0)

--- a/postprocessing/Consumer.py
+++ b/postprocessing/Consumer.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import socket
 import os
+import signal
 import stomp
 
 HEARTBEAT_DELAY = 30
@@ -200,6 +201,13 @@ class Consumer:
         self.procList = []
         self.instrument_jobs = {}
         self._connection = None
+        self._exit = False
+
+        signal.signal(signal.SIGTERM, self.exit_gracefully)
+        signal.signal(signal.SIGINT, self.exit_gracefully)
+
+    def exit_gracefully(self, *args):
+        self._exit = True
 
     def get_connection(self, listener=None):
         """
@@ -249,7 +257,7 @@ class Consumer:
         """
 
         last_heartbeat = 0
-        while True:
+        while not self._exit:
             try:
                 if self._connection is None or self._connection.is_connected() is False:
                     self.connect()

--- a/postprocessing/PostProcessAdmin.py
+++ b/postprocessing/PostProcessAdmin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Post-processing tasks
 
@@ -121,7 +121,7 @@ class PostProcessAdmin:
                     f"{self.instrument}_{self.proposal}_runsummary.csv",
                 )
                 cmd = (
-                    "python "
+                    "python3 "
                     + summary_script
                     + " "
                     + self.instrument

--- a/postprocessing/PostProcessAdmin.py
+++ b/postprocessing/PostProcessAdmin.py
@@ -27,7 +27,7 @@ import stomp
 
 class PostProcessAdmin:
     def __init__(self, data, conf):
-        logging.debug("json data: %s [%s]" % (str(data), type(data)))
+        logging.debug("json data: %s [%s]", str(data), type(data))
         if not isinstance(data, dict):
             raise ValueError("PostProcessAdmin expects a data dictionary")
         data["information"] = socket.gethostname()
@@ -53,10 +53,10 @@ class PostProcessAdmin:
             self.data_file = str(data["data_file"])
             if os.access(self.data_file, os.R_OK) is False:
                 raise ValueError(
-                    "Data file does not exist or is not readable: %s" % self.data_file
+                    f"Data file does not exist or is not readable: {self.data_file}"
                 )
         else:
-            raise ValueError("data_file is missing: %s" % self.data_file)
+            raise ValueError(f"data_file is missing: {self.data_file}")
 
         if "facility" in data:
             self.facility = str(data["facility"]).upper()
@@ -104,7 +104,7 @@ class PostProcessAdmin:
             # Allow for an alternate output directory, if defined
             if len(self.conf.dev_output_dir) > 0:
                 proposal_shared_dir = self.conf.dev_output_dir
-            logging.info("Using output directory: %s" % proposal_shared_dir)
+            logging.info("Using output directory: %s", proposal_shared_dir)
 
             # Set logging directory
             log_dir = os.path.join(proposal_shared_dir, "reduction_log")
@@ -113,12 +113,12 @@ class PostProcessAdmin:
 
             # Look for run summary script
             summary_script = os.path.join(
-                instrument_shared_dir, "sumRun_%s.py" % self.instrument
+                instrument_shared_dir, f"sumRun_{self.instrument}.py"
             )
             if os.path.exists(summary_script) is True:
                 summary_output = os.path.join(
                     proposal_shared_dir,
-                    "%s_%s_runsummary.csv" % (self.instrument, self.proposal),
+                    f"{self.instrument}_{self.proposal}_runsummary.csv",
                 )
                 cmd = (
                     "python "
@@ -136,7 +136,7 @@ class PostProcessAdmin:
 
             # Look for auto-reduction script
             reduce_script_path = os.path.join(
-                instrument_shared_dir, "reduce_%s.py" % self.instrument
+                instrument_shared_dir, f"reduce_{self.instrument}.py"
             )
             if os.path.exists(reduce_script_path) is False:
                 self.send(
@@ -170,8 +170,8 @@ class PostProcessAdmin:
             else:
                 self.send("/queue/" + self.conf.reduction_error, json.dumps(self.data))
         except:  # noqa: E722
-            logging.error("reduce: %s" % sys.exc_info()[1])
-            self.data["error"] = "Reduction: %s " % sys.exc_info()[1]
+            logging.error("reduce: %s", sys.exc_info()[1])
+            self.data["error"] = f"Reduction: {sys.exc_info()[1]}"
             self.send("/queue/" + self.conf.reduction_error, json.dumps(self.data))
 
     def create_reduction_script(self):
@@ -186,7 +186,7 @@ class PostProcessAdmin:
                 self.data, configuration=self.conf, send_function=self.send
             )
         except:  # noqa: E722
-            logging.error("create_reduction_script: %s" % sys.exc_info()[1])
+            logging.error("create_reduction_script: %s", sys.exc_info()[1])
 
     def send(self, destination, data):
         """
@@ -194,7 +194,7 @@ class PostProcessAdmin:
         @param destination: AMQ queue to send to
         @param data: payload of the message
         """
-        logging.info("%s: %s" % (destination, data))
+        logging.info("%s: %s", destination, data)
         conn = stomp.Connection(host_and_ports=self.conf.brokers)
         conn.connect(self.conf.amq_user, self.conf.amq_pwd, wait=True)
         conn.send(destination, data.encode())
@@ -253,12 +253,12 @@ if __name__ == "__main__":
             if isinstance(
                 configuration.reduction_data_ready, list
             ) and namespace.queue in [
-                "/queue/%s" % q for q in configuration.reduction_data_ready
+                f"/queue/{q}" for q in configuration.reduction_data_ready
             ]:
                 pp.reduce()
-            elif namespace.queue == "/queue/%s" % configuration.reduction_data_ready:
+            elif namespace.queue == f"/queue/{configuration.reduction_data_ready}":
                 pp.reduce()
-            elif namespace.queue == "/queue/%s" % configuration.create_reduction_script:
+            elif namespace.queue == f"/queue/{configuration.create_reduction_script}":
                 pp.create_reduction_script()
 
             # Check for registered processors
@@ -267,10 +267,10 @@ if __name__ == "__main__":
                     toks = p.split(".")
                     if len(toks) == 2:
                         processor_module = importlib.import_module(
-                            "postprocessing.processors.%s" % toks[0]
+                            f"postprocessing.processors.{toks[0]}"
                         )
                         try:
-                            processor_class = eval("processor_module.%s" % toks[1])
+                            processor_class = eval(f"processor_module.{toks[1]}")
                             if (
                                 namespace.queue
                                 == processor_class.get_input_queue_name()
@@ -282,8 +282,8 @@ if __name__ == "__main__":
                                 proc()
                         except:  # noqa: E722
                             logging.error(
-                                "PostProcessAdmin: Processor error: %s"
-                                % sys.exc_info()[1]
+                                "PostProcessAdmin: Processor error: %s",
+                                sys.exc_info()[1],
                             )
                     else:
                         logging.error(
@@ -300,4 +300,4 @@ if __name__ == "__main__":
                 conn.disconnect()
             raise
     except:  # noqa: E722
-        logging.error("PostProcessAdmin: %s" % sys.exc_info()[1])
+        logging.error("PostProcessAdmin: %s", sys.exc_info()[1])

--- a/postprocessing/processors/base_processor.py
+++ b/postprocessing/processors/base_processor.py
@@ -12,7 +12,7 @@ import json
 from . import job_handling
 
 
-class BaseProcessor(object):
+class BaseProcessor:
     """
     Base class for job processor
     """
@@ -62,15 +62,15 @@ class BaseProcessor(object):
         if not os.path.isfile(script):
             self.process_error(
                 self.configuration.reduction_error,
-                "Script %s does not exist" % str(script),
+                f"Script {script} does not exist",
             )
 
         # Remove old log files
         out_log = os.path.join(
-            self.log_dir, "%s.%s.log" % (os.path.basename(self.data_file), job_name)
+            self.log_dir, f"{os.path.basename(self.data_file)}.{job_name}.log"
         )
         out_err = os.path.join(
-            self.log_dir, "%s.%s.err" % (os.path.basename(self.data_file), job_name)
+            self.log_dir, f"{os.path.basename(self.data_file)}.{job_name}.err"
         )
         if os.path.isfile(out_err):
             os.remove(out_err)
@@ -98,10 +98,10 @@ class BaseProcessor(object):
             self.data_file = str(data["data_file"])
             if os.access(self.data_file, os.R_OK) is False:
                 raise ValueError(
-                    "Data file does not exist or is not readable: %s" % self.data_file
+                    f"Data file does not exist or is not readable: {self.data_file}"
                 )
         else:
-            raise ValueError("data_file is missing: %s" % self.data_file)
+            raise ValueError(f"data_file is missing: {self.data_file}")
 
         if "facility" in data:
             self.facility = str(data["facility"]).upper()
@@ -139,7 +139,7 @@ class BaseProcessor(object):
         error_message = "%s: %s" % (type(self).__name__, message)
         logging.error(error_message)
         self.data["error"] = error_message
-        self.send("/queue/%s" % destination, json.dumps(self.data).encode())
+        self.send(f"/queue/{destination}", json.dumps(self.data).encode())
         # Reset the error and information
         if "information" in self.data:
             del self.data["information"]

--- a/postprocessing/processors/calvera_processor.py
+++ b/postprocessing/processors/calvera_processor.py
@@ -38,10 +38,10 @@ class CalveraProcessor(BaseProcessor):
                 success = True
             else:
                 success = False
-                res["error"] = "SENDING TO Calvera: %s" % response.text
+                res["error"] = f"SENDING TO Calvera: {response.text}"
         except Exception as e:
             success = False
-            res["error"] = "SENDING TO Calvera: %s" % str(e)
+            res["error"] = f"SENDING TO Calvera: {e}"
 
         return success, res
 

--- a/postprocessing/processors/oncat_processor.py
+++ b/postprocessing/processors/oncat_processor.py
@@ -22,21 +22,12 @@ class ONCatProcessor(BaseProcessor):
     ERROR_QUEUE = "/queue/CATALOG.ONCAT.ERROR"
     SCRIPT_PATH = "/opt/postprocessing/scripts/oncat_ingest.py"
 
-    def __init__(self, data, conf, send_function):
-        """
-        Initialize the processor
-        @param data: data dictionary from the incoming message
-        @param conf: configuration object
-        @param send_function: function to call to send AMQ messages
-        """
-        super(ONCatProcessor, self).__init__(data, conf, send_function)
-
     def __call__(self):
         """
         Execute the job
         """
         if not os.path.isfile(self.SCRIPT_PATH):
-            self.data["information"] = "ONCat script not found: %s" % self.SCRIPT_PATH
+            self.data["information"] = f"ONCat script not found: {self.SCRIPT_PATH}"
             self.send(self.ERROR_QUEUE, json.dumps(self.data))
             return
 

--- a/postprocessing/processors/oncat_reduced_processor.py
+++ b/postprocessing/processors/oncat_reduced_processor.py
@@ -22,21 +22,12 @@ class ONCatProcessor(BaseProcessor):
     ERROR_QUEUE = "/queue/CATALOG.ERROR"
     SCRIPT_PATH = "/opt/postprocessing/scripts/oncat_reduced_ingest.py"
 
-    def __init__(self, data, conf, send_function):
-        """
-        Initialize the processor
-        @param data: data dictionary from the incoming message
-        @param conf: configuration object
-        @param send_function: function to call to send AMQ messages
-        """
-        super(ONCatProcessor, self).__init__(data, conf, send_function)
-
     def __call__(self):
         """
         Execute the job
         """
         if not os.path.isfile(self.SCRIPT_PATH):
-            self.data["information"] = "ONCat script not found: %s" % self.SCRIPT_PATH
+            self.data["information"] = f"ONCat script not found: {self.SCRIPT_PATH}"
             self.send(self.ERROR_QUEUE, json.dumps(self.data))
             return
 

--- a/postprocessing/processors/test_processor.py
+++ b/postprocessing/processors/test_processor.py
@@ -14,16 +14,6 @@ class TestProcessor(BaseProcessor):
     ## Input queue
     _message_queue = "/queue/REDUCTION.TESTPROCESSOR.DATA_READY"
 
-    def __init__(self, data, conf, send_function):
-        """
-        Initialize the processor
-
-        @param data: data dictionary from the incoming message
-        @param conf: configuration object
-        @param send_function: function to call to send AMQ messages
-        """
-        super(TestProcessor, self).__init__(data, conf, send_function)
-
     def __call__(self):
         """
         Just send back acknowledgment messages

--- a/postprocessing/publish_plot.py
+++ b/postprocessing/publish_plot.py
@@ -48,7 +48,7 @@ def publish_plot(instrument, run_number, files, config_file=None):
 
     status_code = request.status_code
     if status_code != 200:
-        raise RuntimeError("post returned %d" % status_code)
+        raise RuntimeError(f"post returned {status_code}")
     return request
 
 

--- a/postprocessing/queueProcessor.py
+++ b/postprocessing/queueProcessor.py
@@ -13,13 +13,9 @@ from postprocessing.Configuration import read_configuration
 configuration = read_configuration()
 
 from postprocessing.Consumer import Consumer
-from twisted.internet import reactor, task
 
 logging.info("Starting post-processing listener %s" % postprocessing.__version__)
 configuration.log_configuration()
 
 consumer = Consumer(configuration)
-heartbeat = task.LoopingCall(consumer.heartbeat)
-heartbeat.start(30.0)
-consumer.run()
-reactor.run()
+consumer.listen_and_wait(0.01)

--- a/postprocessing/queueProcessor.py
+++ b/postprocessing/queueProcessor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
     Post-processing agent start script
 

--- a/postprocessing/queueProcessor.py
+++ b/postprocessing/queueProcessor.py
@@ -14,7 +14,7 @@ configuration = read_configuration()
 
 from postprocessing.Consumer import Consumer
 
-logging.info("Starting post-processing listener %s" % postprocessing.__version__)
+logging.info("Starting post-processing listener %s", postprocessing.__version__)
 configuration.log_configuration()
 
 consumer = Consumer(configuration)

--- a/postprocessing/reduction_script_writer.py
+++ b/postprocessing/reduction_script_writer.py
@@ -40,10 +40,10 @@ import sys
 import shutil
 import string
 import time
-import urllib.request, urllib.parse, urllib.error
+import urllib.parse
 
 
-class ScriptWriter(object):
+class ScriptWriter:
     """
     Script writer class
     """
@@ -92,7 +92,8 @@ class ScriptWriter(object):
         Return a list of template arguments
         """
         if self._template_content is None:
-            self._template_content = open(self._template_path).read()
+            with open(self._template_path) as template_file:
+                self._template_content = template_file.read()
 
         tag_list = re.findall(r"\$(\w+)", self._template_content)
         tag_list.extend(re.findall(r"\${(\w+)}", self._template_content))
@@ -110,7 +111,7 @@ class ScriptWriter(object):
             if item not in template_args:
                 missing_args.append(item)
         if len(missing_args) > 0:
-            raise KeyError("Template arguments missing: %s" % str(missing_args))
+            raise KeyError(f"Template arguments missing: {missing_args}")
 
     def write_script(self, **template_args):
         r"""Write the script using a template
@@ -120,20 +121,20 @@ class ScriptWriter(object):
         self.check_arguments(**template_args)
         # If we use a template, make sure we load it first
         if self._template_content is None:
-            self._template_content = open(self._template_path).read()
+            with open(self._template_path) as template_file:
+                self._template_content = template_file.read()
         # Replace the dictionary entries
         template = string.Template(self._template_content)
         script = template.substitute(**template_args)
         # Write the script
         if os.path.isdir(self.autoreduction_dir):
-            script_file = open(
+            with open(
                 os.path.join(self.autoreduction_dir, self.script_name), "w"
-            )
-            script_file.write(script)
-            script_file.close()
+            ) as script_file:
+                script_file.write(script)
         else:
             raise RuntimeError(
-                "Script directory does not exist: %s" % self.autoreduction_dir
+                f"Script directory does not exist: {self.autoreduction_dir}"
             )
 
     def log_entry(self, **template_args):
@@ -147,7 +148,7 @@ class ScriptWriter(object):
                 str(template_args[k]).replace("\n", "; ") for k in template_keys
             ]
             template_keys.insert(0, "Time")
-            template_values.insert(0, "%s" % time.ctime())
+            template_values.insert(0, str(time.ctime()))
             log_entry = ""
             # If the file doesn't exist, create it with a header line
             if not os.path.isfile(self.log_file):
@@ -155,13 +156,13 @@ class ScriptWriter(object):
                 log_entry += "\n"
             log_entry += "\t ".join(template_values)
             log_entry += "\n"
-            log_file = open(self.log_file, "a")
-            log_file.write(log_entry)
-            log_file.close()
+            with open(self.log_file, "a") as log_file:
+                log_file.write(log_entry)
         except Exception:
             logging.error(
-                "ScriptWriter: Could not write log entry for %s: %s"
-                % (self.script_name, sys.exc_info()[1])
+                "ScriptWriter: Could not write log entry for %s: %s",
+                self.script_name,
+                sys.exc_info()[1],
             )
 
     def process_request(self, request_data, configuration, send_function):
@@ -201,8 +202,7 @@ class ScriptWriter(object):
                     )
                     if not os.path.isfile(default_script_path):
                         raise RuntimeError(
-                            "ScriptWriter: Could not find script %s"
-                            % self.default_script_name
+                            f"ScriptWriter: Could not find script {self.default_script_name}",
                         )
                     shutil.copy(
                         default_script_path,
@@ -215,8 +215,7 @@ class ScriptWriter(object):
                     # Verify that the template file exists
                     if not os.path.isfile(self._template_path):
                         raise RuntimeError(
-                            "ScriptWriter: Could not find template %s"
-                            % self.template_name
+                            f"ScriptWriter: Could not find template {self.template_name}"
                         )
 
                     self.check_arguments(**template_data)

--- a/scripts/ar-report.py
+++ b/scripts/ar-report.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import absolute_import, division, print_function, unicode_literals
 import h5py
 import os

--- a/scripts/ar-report.py
+++ b/scripts/ar-report.py
@@ -13,7 +13,7 @@ shareddirlist = []
 reduceloglist = []
 
 
-class GenericFile(object):
+class GenericFile:
     def __init__(self, path):
         self.filename = path
         self.timeCreation = None
@@ -67,7 +67,7 @@ class GenericFile(object):
 
 class ReductionLogFile(GenericFile):
     def __init__(self, logfullname, eventfilename):
-        super(ReductionLogFile, self).__init__(logfullname)
+        super().__init__(logfullname)
         self.mantidVersion = "UNKNOWN"
         self.longestDuration = 0.0
         self.longestAlgorithm = ""
@@ -309,7 +309,7 @@ class ARstatus:
 
 class EventFile(GenericFile):
     def __init__(self, direc, filename):
-        super(EventFile, self).__init__(os.path.join(direc, filename))
+        super().__init__(os.path.join(direc, filename))
         self.shortname = filename
         self.prefix = filename.replace(".nxs.h5", "").replace("_event.nxs", "")
 

--- a/scripts/mantidpython.py
+++ b/scripts/mantidpython.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/bin/env python3
 import os
 import re
 import subprocess

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ this_module_path = sys.modules[__name__].__file__
 def data_server():
     r"""Object containing info and functionality for data files"""
 
-    class _DataServe(object):
+    class _DataServe:
         _directory = os.path.join(os.path.dirname(this_module_path), "data")
 
         @property

--- a/tests/data/post_processing.conf
+++ b/tests/data/post_processing.conf
@@ -1,5 +1,6 @@
 {
     "failover_uri": "failover:(tcp://amqbroker.sns.gov:61613)?randomize=false,startupMaxReconnectAttempts=100,initialReconnectDelay=1000,maxReconnectDelay=5000,maxReconnectAttempts=-1",
+    "brokers": [["amqbroker.sns.gov", 61613]],
     "amq_queues": ["/queue/REDUCTION.CREATE_SCRIPT", "/queue/REDUCTION.DATA_READY", "/queue/CATALOG.DATA_READY"],
     "amq_user": "wfclient",
     "amq_pwd": "w0rkfl0w",

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,21 +1,19 @@
-FROM mambaorg/micromamba
+FROM registry.access.redhat.com/ubi9/ubi
 
-COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml .
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+RUN dnf update
+RUN dnf install -y python3-requests python3-stomppy python3-pip python3-coverage
+RUN python3 -m pip install plotly
 
-RUN micromamba install --yes -n base --file environment.yml
+COPY postprocessing /opt/postprocessing/postprocessing
+COPY tests/integration/post_processing.conf /etc/autoreduce/post_processing.conf
 
-ARG MAMBA_DOCKERFILE_ACTIVATE=1
-
-COPY --chown=$MAMBA_USER:$MAMBA_USER postprocessing /opt/postprocessing/postprocessing
-COPY --chown=$MAMBA_USER:$MAMBA_USER tests/integration/post_processing.conf /etc/autoreduce/post_processing.conf
-
-RUN echo \#\!/bin/bash > /opt/conda/bin/coverage_run && \
-    echo coverage run \$@ >> /opt/conda/bin/coverage_run && \
-    chmod +x /opt/conda/bin/coverage_run
+RUN echo \#\!/bin/bash > /usr/bin/coverage_run && \
+    echo coverage run \$@ >> /usr/bin/coverage_run && \
+    chmod +x /usr/bin/coverage_run
 
 ENV PYTHONPATH /opt/postprocessing
 
-USER root
 RUN echo -e "[run]\nsource=postprocessing\nparallel=True\nrelative_files=True" > /opt/postprocessing/.coveragerc
 RUN mkdir -p /opt/postprocessing/log && \
     mkdir -p /opt/postprocessing/scripts && \
@@ -39,8 +37,6 @@ RUN mkdir -p /opt/postprocessing/log && \
     echo "a=\${value}" > /SNS/TOPAZ/shared/autoreduce/reduce_TOPAZ.py.template && \
     \
     chown -R $MAMBA_USER:$MAMBA_USER /opt/postprocessing /SNS
-
-USER $MAMBA_USER
 
 WORKDIR /opt/postprocessing
 ENV COVERAGE_PROCESS_START /opt/postprocessing/.coveragerc

--- a/tests/integration/post_processing.conf
+++ b/tests/integration/post_processing.conf
@@ -1,5 +1,6 @@
 {
     "failover_uri": "failover:(tcp://activemq:61613)?randomize=false,startupMaxReconnectAttempts=100,initialReconnectDelay=1000,maxReconnectDelay=5000,maxReconnectAttempts=-1",
+    "brokers": [["activemq", 61613]],
     "amq_queues": ["/queue/REDUCTION.CREATE_SCRIPT", "/queue/REDUCTION.DATA_READY", "/queue/CATALOG.DATA_READY"],
     "amq_user": "",
     "amq_pwd": "",

--- a/tests/integration/test_cataloging.py
+++ b/tests/integration/test_cataloging.py
@@ -15,7 +15,7 @@ def test_oncat_catalog():
 
     conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
 
-    listener = stomp.listener.TestListener(print_to_log=False)
+    listener = stomp.listener.TestListener()
     conn.set_listener("", listener)
 
     try:
@@ -55,7 +55,7 @@ def test_oncat_reduction_catalog():
 
     conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
 
-    listener = stomp.listener.TestListener(print_to_log=False)
+    listener = stomp.listener.TestListener()
     conn.set_listener("", listener)
 
     try:
@@ -95,7 +95,7 @@ def test_calvera():
 
     conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
 
-    listener = stomp.listener.TestListener(print_to_log=False)
+    listener = stomp.listener.TestListener()
     conn.set_listener("", listener)
 
     try:
@@ -140,7 +140,7 @@ def test_calvera_reduced():
 
     conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
 
-    listener = stomp.listener.TestListener(print_to_log=False)
+    listener = stomp.listener.TestListener()
     conn.set_listener("", listener)
 
     try:

--- a/tests/integration/test_cataloging.py
+++ b/tests/integration/test_cataloging.py
@@ -1,10 +1,6 @@
 import json
 import pytest
 
-from stompest.config import StompConfig
-from stompest.sync import Stomp
-from stompest.error import StompConnectTimeout
-
 
 def test_oncat_catalog():
     """This should run ONCatProcessor"""

--- a/tests/integration/test_cataloging.py
+++ b/tests/integration/test_cataloging.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+import stomp
 
 
 def test_oncat_catalog():
@@ -12,24 +13,29 @@ def test_oncat_catalog():
         "data_file": "/SNS/EQSANS/IPTS-10674/0/30892/NeXus/EQSANS_30892_event.nxs",
     }
 
-    client = Stomp(StompConfig("tcp://localhost:61613"))
+    conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
+
+    listener = stomp.listener.TestListener(print_to_log=False)
+    conn.set_listener("", listener)
+
     try:
-        client.connect()
-    except StompConnectTimeout:
+        conn.connect()
+    except stomp.exception.ConnectFailedException:
         pytest.skip("Requires activemq running")
 
-    # send data ready
-    client.send("/queue/CATALOG.ONCAT.DATA_READY", json.dumps(message).encode())
-
     # expect a message on CATALOG.ONCAT.COMPLETE
-    client.subscribe("/queue/CATALOG.ONCAT.COMPLETE")
+    conn.subscribe("/queue/CATALOG.ONCAT.COMPLETE", id="123", ack="auto")
 
-    assert client.canRead(5)
-    frame = client.receiveFrame()
+    # send data ready
+    conn.send("/queue/CATALOG.ONCAT.DATA_READY", json.dumps(message).encode())
 
-    client.disconnect()
+    listener.wait_for_message()
 
-    msg = json.loads(frame.body)
+    conn.disconnect()
+
+    header, body = listener.get_latest_message()
+
+    msg = json.loads(body)
     assert msg["run_number"] == message["run_number"]
     assert msg["instrument"] == message["instrument"]
     assert msg["ipts"] == message["ipts"]
@@ -47,24 +53,29 @@ def test_oncat_reduction_catalog():
         "data_file": "/SNS/EQSANS/IPTS-10674/0/30892/NeXus/EQSANS_30892_event.nxs",
     }
 
-    client = Stomp(StompConfig("tcp://localhost:61613"))
+    conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
+
+    listener = stomp.listener.TestListener(print_to_log=False)
+    conn.set_listener("", listener)
+
     try:
-        client.connect()
-    except StompConnectTimeout:
+        conn.connect()
+    except stomp.exception.ConnectFailedException:
         pytest.skip("Requires activemq running")
 
-    # send data ready
-    client.send("/queue/REDUCTION_CATALOG.DATA_READY", json.dumps(message).encode())
-
     # expect a message on REDUCTION_CATALOG.COMPLETE
-    client.subscribe("/queue/REDUCTION_CATALOG.COMPLETE")
+    conn.subscribe("/queue/REDUCTION_CATALOG.COMPLETE", id="123", ack="auto")
 
-    assert client.canRead(5)
-    frame = client.receiveFrame()
+    # send data ready
+    conn.send("/queue/REDUCTION_CATALOG.DATA_READY", json.dumps(message).encode())
 
-    client.disconnect()
+    listener.wait_for_message()
 
-    msg = json.loads(frame.body)
+    conn.disconnect()
+
+    header, body = listener.get_latest_message()
+
+    msg = json.loads(body)
     assert msg["run_number"] == message["run_number"]
     assert msg["instrument"] == message["instrument"]
     assert msg["ipts"] == message["ipts"]
@@ -82,24 +93,29 @@ def test_calvera():
         "data_file": "/SNS/EQSANS/IPTS-10674/0/30892/NeXus/EQSANS_30892_event.nxs",
     }
 
-    client = Stomp(StompConfig("tcp://localhost:61613"))
+    conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
+
+    listener = stomp.listener.TestListener(print_to_log=False)
+    conn.set_listener("", listener)
+
     try:
-        client.connect()
-    except StompConnectTimeout:
+        conn.connect()
+    except stomp.exception.ConnectFailedException:
         pytest.skip("Requires activemq running")
 
-    # send data ready
-    client.send("/queue/CALVERA.RAW.DATA_READY", json.dumps(message).encode())
-
     # expect an error
-    client.subscribe("/queue/CALVERA.RAW.ERROR")
+    conn.subscribe("/queue/CALVERA.RAW.ERROR", id="123", ack="auto")
 
-    assert client.canRead(5)
-    frame = client.receiveFrame()
+    # send data ready
+    conn.send("/queue/CALVERA.RAW.DATA_READY", json.dumps(message).encode())
 
-    client.disconnect()
+    listener.wait_for_message()
 
-    msg = json.loads(frame.body)
+    conn.disconnect()
+
+    header, body = listener.get_latest_message()
+
+    msg = json.loads(body)
     assert msg["run_number"] == message["run_number"]
     assert msg["instrument"] == message["instrument"]
     assert msg["ipts"] == message["ipts"]
@@ -122,24 +138,29 @@ def test_calvera_reduced():
         "data_file": "/SNS/EQSANS/IPTS-10674/0/30892/NeXus/EQSANS_30892_event.nxs",
     }
 
-    client = Stomp(StompConfig("tcp://localhost:61613"))
+    conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
+
+    listener = stomp.listener.TestListener(print_to_log=False)
+    conn.set_listener("", listener)
+
     try:
-        client.connect()
-    except StompConnectTimeout:
+        conn.connect()
+    except stomp.exception.ConnectFailedException:
         pytest.skip("Requires activemq running")
 
-    # send data ready
-    client.send("/queue/CALVERA.REDUCED.DATA_READY", json.dumps(message).encode())
-
     # expect an error
-    client.subscribe("/queue/CALVERA.REDUCED.ERROR")
+    conn.subscribe("/queue/CALVERA.REDUCED.ERROR", id="123", ack="auto")
 
-    assert client.canRead(5)
-    frame = client.receiveFrame()
+    # send data ready
+    conn.send("/queue/CALVERA.REDUCED.DATA_READY", json.dumps(message).encode())
 
-    client.disconnect()
+    listener.wait_for_message()
 
-    msg = json.loads(frame.body)
+    conn.disconnect()
+
+    header, body = listener.get_latest_message()
+
+    msg = json.loads(body)
     assert msg["run_number"] == message["run_number"]
     assert msg["instrument"] == message["instrument"]
     assert msg["ipts"] == message["ipts"]

--- a/tests/integration/test_create_script.py
+++ b/tests/integration/test_create_script.py
@@ -3,9 +3,7 @@ import json
 import pytest
 from tests.conftest import docker_exec_and_cat
 
-from stompest.config import StompConfig
-from stompest.sync import Stomp
-from stompest.error import StompConnectTimeout
+import stomp
 
 
 def test_default():
@@ -13,16 +11,16 @@ def test_default():
 
     message = {"instrument": "TOPAZ", "use_default": True, "template_data": {}}
 
-    client = Stomp(StompConfig("tcp://localhost:61613"))
+    conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
     try:
-        client.connect()
-    except StompConnectTimeout:
+        conn.connect()
+    except stomp.exception.ConnectFailedException:
         pytest.skip("Requires activemq running")
 
     # send data ready
-    client.send("/queue/REDUCTION.CREATE_SCRIPT", json.dumps(message).encode())
+    conn.send("/queue/REDUCTION.CREATE_SCRIPT", json.dumps(message).encode())
 
-    client.disconnect()
+    conn.disconnect()
 
     time.sleep(1)
 
@@ -41,16 +39,16 @@ def test_template():
         "template_data": {"value": 42},
     }
 
-    client = Stomp(StompConfig("tcp://localhost:61613"))
+    conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
     try:
-        client.connect()
-    except StompConnectTimeout:
+        conn.connect()
+    except stomp.exception.ConnectFailedException:
         pytest.skip("Requires activemq running")
 
     # send data ready
-    client.send("/queue/REDUCTION.CREATE_SCRIPT", json.dumps(message).encode())
+    conn.send("/queue/REDUCTION.CREATE_SCRIPT", json.dumps(message).encode())
 
-    client.disconnect()
+    conn.disconnect()
 
     time.sleep(1)
 

--- a/tests/integration/test_data_ready.py
+++ b/tests/integration/test_data_ready.py
@@ -24,6 +24,7 @@ def test_missing_data():
     except stomp.exception.ConnectFailedException:
         pytest.skip("Requires activemq running")
 
+    # expect a reduction disabled
     conn.subscribe(destination="/queue/POSTPROCESS.ERROR", id="123", ack="auto")
 
     # send data ready
@@ -33,9 +34,9 @@ def test_missing_data():
 
     conn.disconnect()
 
-    header, data = listener.get_latest_message()
+    header, body = listener.get_latest_message()
 
-    msg = json.loads(data)
+    msg = json.loads(body)
     assert (
         msg["error"]
         == "Data file does not exist or is not readable: /SNS/DOES_NOT_EXIST.nxs"
@@ -51,24 +52,29 @@ def test_disabled_reduction():
         "data_file": "/SNS/EQSANS/IPTS-10674/0/30892/NeXus/EQSANS_30892_event.nxs",
     }
 
-    client = Stomp(StompConfig("tcp://localhost:61613"))
+    conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
+
+    listener = stomp.listener.TestListener(print_to_log=False)
+    conn.set_listener("", listener)
+
     try:
-        client.connect()
-    except StompConnectTimeout:
+        conn.connect()
+    except stomp.exception.ConnectFailedException:
         pytest.skip("Requires activemq running")
 
-    # send data ready
-    client.send("/queue/REDUCTION.DATA_READY", json.dumps(message).encode())
-
     # expect a reduction disabled
-    client.subscribe("/queue/REDUCTION.DISABLED")
+    conn.subscribe("/queue/REDUCTION.DISABLED", id="123", ack="auto")
 
-    assert client.canRead(5)
-    frame = client.receiveFrame()
+    # send data ready
+    conn.send("/queue/REDUCTION.DATA_READY", json.dumps(message).encode())
 
-    client.disconnect()
+    listener.wait_for_message()
 
-    msg = json.loads(frame.body)
+    conn.disconnect()
+
+    header, body = listener.get_latest_message()
+
+    msg = json.loads(body)
     assert msg["run_number"] == message["run_number"]
     assert msg["instrument"] == message["instrument"]
     assert msg["ipts"] == message["ipts"]
@@ -85,24 +91,29 @@ def test_reduction():
         "data_file": "/SNS/EQSANS/IPTS-10674/0/30892/NeXus/EQSANS_30892_event.nxs",
     }
 
-    client = Stomp(StompConfig("tcp://localhost:61613"))
+    conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
+
+    listener = stomp.listener.TestListener(print_to_log=False)
+    conn.set_listener("", listener)
+
     try:
-        client.connect()
-    except StompConnectTimeout:
+        conn.connect()
+    except stomp.exception.ConnectFailedException:
         pytest.skip("Requires activemq running")
 
-    # send data ready
-    client.send("/queue/REDUCTION.DATA_READY", json.dumps(message).encode())
-
     # expect a reduction complete
-    client.subscribe("/queue/REDUCTION.COMPLETE")
+    conn.subscribe("/queue/REDUCTION.COMPLETE", id="123", ack="auto")
 
-    assert client.canRead(5)
-    frame = client.receiveFrame()
+    # send data ready
+    conn.send("/queue/REDUCTION.DATA_READY", json.dumps(message).encode())
 
-    client.disconnect()
+    listener.wait_for_message()
 
-    msg = json.loads(frame.body)
+    conn.disconnect()
+
+    header, body = listener.get_latest_message()
+
+    msg = json.loads(body)
     assert msg["run_number"] == message["run_number"]
     assert msg["instrument"] == message["instrument"]
     assert msg["ipts"] == message["ipts"]
@@ -129,24 +140,29 @@ def test_reduction_error():
         "data_file": "/SNS/CORELLI/IPTS-15526/nexus/CORELLI_29666.nxs.h5",
     }
 
-    client = Stomp(StompConfig("tcp://localhost:61613"))
+    conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
+
+    listener = stomp.listener.TestListener(print_to_log=False)
+    conn.set_listener("", listener)
+
     try:
-        client.connect()
-    except StompConnectTimeout:
+        conn.connect()
+    except stomp.exception.ConnectFailedException:
         pytest.skip("Requires activemq running")
 
-    # send data ready
-    client.send("/queue/REDUCTION.DATA_READY", json.dumps(message).encode())
-
     # expect a reduction error
-    client.subscribe("/queue/REDUCTION.ERROR")
+    conn.subscribe("/queue/REDUCTION.ERROR", id="123", ack="auto")
 
-    assert client.canRead(5)
-    frame = client.receiveFrame()
+    # send data ready
+    conn.send("/queue/REDUCTION.DATA_READY", json.dumps(message).encode())
 
-    client.disconnect()
+    listener.wait_for_message()
 
-    msg = json.loads(frame.body)
+    conn.disconnect()
+
+    header, body = listener.get_latest_message()
+
+    msg = json.loads(body)
     assert msg["run_number"] == message["run_number"]
     assert msg["instrument"] == message["instrument"]
     assert msg["ipts"] == message["ipts"]

--- a/tests/integration/test_data_ready.py
+++ b/tests/integration/test_data_ready.py
@@ -16,7 +16,7 @@ def test_missing_data():
 
     conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
 
-    listener = stomp.listener.TestListener(print_to_log=False)
+    listener = stomp.listener.TestListener()
     conn.set_listener("", listener)
 
     try:
@@ -54,7 +54,7 @@ def test_disabled_reduction():
 
     conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
 
-    listener = stomp.listener.TestListener(print_to_log=False)
+    listener = stomp.listener.TestListener()
     conn.set_listener("", listener)
 
     try:
@@ -93,7 +93,7 @@ def test_reduction():
 
     conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
 
-    listener = stomp.listener.TestListener(print_to_log=False)
+    listener = stomp.listener.TestListener()
     conn.set_listener("", listener)
 
     try:
@@ -142,7 +142,7 @@ def test_reduction_error():
 
     conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
 
-    listener = stomp.listener.TestListener(print_to_log=False)
+    listener = stomp.listener.TestListener()
     conn.set_listener("", listener)
 
     try:

--- a/tests/integration/test_heartbeat.py
+++ b/tests/integration/test_heartbeat.py
@@ -1,24 +1,30 @@
 import json
 import pytest
+import stomp
 
 
 def test_heartbeat():
     """While the queue processor is running, every 30 seconds it should send a message to /topic/SNS.COMMON.STATUS.AUTOREDUCE.0 with the hostname and pid"""
 
-    client = Stomp(StompConfig("tcp://localhost:61613"))
+    conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
+
+    listener = stomp.listener.TestListener(print_to_log=False)
+    conn.set_listener("", listener)
+
     try:
-        client.connect()
-    except StompConnectTimeout:
+        conn.connect()
+    except stomp.exception.ConnectFailedException:
         pytest.skip("Requires activemq running")
 
-    client.subscribe("/topic/SNS.COMMON.STATUS.AUTOREDUCE.0")
+    conn.subscribe("/topic/SNS.COMMON.STATUS.AUTOREDUCE.0", id="123", ack="auto")
 
-    assert client.canRead(60)  # wait for heartbeat, should be one every 30 seconds
-    frame = client.receiveFrame()
+    listener.wait_for_message()
 
-    client.disconnect()
+    conn.disconnect()
 
-    data = json.loads(frame.body)
+    header, body = listener.get_latest_message()
+
+    data = json.loads(body)
     assert "src_name" in data
     assert data["role"] == "postprocessing"
     assert data["status"] == "0"
@@ -28,26 +34,30 @@ def test_heartbeat():
 def test_heartbeat_ping():
     """When a message is received at /topic/SNS.COMMON.STATUS.PING this should respond with a heartbeat to reply_to"""
 
-    client = Stomp(StompConfig("tcp://localhost:61613"))
+    conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
+
+    listener = stomp.listener.TestListener(print_to_log=False)
+    conn.set_listener("", listener)
+
     try:
-        client.connect()
-    except StompConnectTimeout:
+        conn.connect()
+    except stomp.exception.ConnectFailedException:
         pytest.skip("Requires activemq running")
 
-    # request a response on /queue/PING_TEST
-    client.send(
+    conn.subscribe("/queue/PING_TEST", id="123", ack="auto")
+
+    conn.send(
         "/topic/SNS.COMMON.STATUS.PING",
         json.dumps({"reply_to": "/queue/PING_TEST"}).encode(),
     )
 
-    client.subscribe("/queue/PING_TEST")
+    listener.wait_for_message()
 
-    assert client.canRead(5)
-    frame = client.receiveFrame()
+    conn.disconnect()
 
-    client.disconnect()
+    header, body = listener.get_latest_message()
 
-    data = json.loads(frame.body)
+    data = json.loads(body)
     assert "src_name" in data
     assert data["role"] == "postprocessing"
     assert data["status"] == "0"

--- a/tests/integration/test_heartbeat.py
+++ b/tests/integration/test_heartbeat.py
@@ -8,7 +8,7 @@ def test_heartbeat():
 
     conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
 
-    listener = stomp.listener.TestListener(print_to_log=False)
+    listener = stomp.listener.TestListener()
     conn.set_listener("", listener)
 
     try:
@@ -36,7 +36,7 @@ def test_heartbeat_ping():
 
     conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
 
-    listener = stomp.listener.TestListener(print_to_log=False)
+    listener = stomp.listener.TestListener()
     conn.set_listener("", listener)
 
     try:

--- a/tests/integration/test_heartbeat.py
+++ b/tests/integration/test_heartbeat.py
@@ -1,10 +1,6 @@
 import json
 import pytest
 
-from stompest.config import StompConfig
-from stompest.sync import Stomp
-from stompest.error import StompConnectTimeout
-
 
 def test_heartbeat():
     """While the queue processor is running, every 30 seconds it should send a message to /topic/SNS.COMMON.STATUS.AUTOREDUCE.0 with the hostname and pid"""

--- a/tests/unit/postprocessing/test_Configuration.py
+++ b/tests/unit/postprocessing/test_Configuration.py
@@ -17,7 +17,7 @@ import tempfile
 import importlib
 
 
-class TestConfiguration(object):
+class TestConfiguration:
     def test_init(self, data_server):
         with pytest.raises(RuntimeError) as exception_info:
             Configuration("no_file")
@@ -64,7 +64,7 @@ def test_read_configuration(data_server, caplog):
         sys.stderr = backup
 
 
-class TestStreamToLogger(object):
+class TestStreamToLogger:
     def test_write(self, test_logger):
         sl = StreamToLogger(test_logger.logger)
         sl.write("Hello\nWorld")

--- a/tests/unit/postprocessing/test_reduction_script_writer.py
+++ b/tests/unit/postprocessing/test_reduction_script_writer.py
@@ -31,7 +31,7 @@ def writer_local(data_server):
     )  # called after all tests in this module finish
 
 
-class TestScriptWriter(object):
+class TestScriptWriter:
     arguments = {
         "mask": """MaskBTPParameters.append({'Pixel': '121-128'})
     MaskBTPParameters.append({'Pixel': '1-8'})


### PR DESCRIPTION
~#30 needs to be merged first~

This introduces a breaking change to the configuration format, requiring a `brokers` entry instead of `failover_uri`.

I followed a similar pattern that was used in https://github.com/neutrons/data_workflow/blob/next/src/dasmon_app/dasmon_listener/amq_consumer.py

Ref [3201](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3201)

I disabled the RPM build because the spec file needs to updated which will be done as part of [2821](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=2821)