### PR TITLE
3294: Fix logging not being recorded from PostProcessAdmin

### DIFF
--- a/postprocessing/Configuration.py
+++ b/postprocessing/Configuration.py
@@ -217,6 +217,25 @@ def initialize_logging(log_file, level=logging.INFO, preemptive_cleanup=False):
         filename=log_file,
         filemode="a",
     )
+
+    ### add a level for subprocess logging
+    # credit: https://stackoverflow.com/a/35804945
+    subprocess_level_str = "SUBPROCESS"
+    subprocess_level_int = logging.INFO + 1
+
+    def logForLevel(self, message, *args, **kwargs):
+        if self.isEnabledFor(subprocess_level_int):
+            self._log(subprocess_level_int, message, *args, **kwargs)
+
+    def logToRoot(message, *args, **kwargs):
+        logging.log(subprocess_level_int, message, *args, **kwargs)
+
+    logging.addLevelName(subprocess_level_int, subprocess_level_str)
+    setattr(logging, subprocess_level_str, subprocess_level_int)
+    setattr(logging.getLoggerClass(), subprocess_level_str.lower(), logForLevel)
+    setattr(logging, subprocess_level_str.lower(), logToRoot)
+
+    ###   redirect stderr
     stderr_logger = logging.getLogger("STDERR")
     sl = StreamToLogger(stderr_logger, logging.ERROR)
     sys.stderr = sl

--- a/postprocessing/Consumer.py
+++ b/postprocessing/Consumer.py
@@ -114,11 +114,12 @@ class Listener(stomp.ConnectionListener):
             logging.warning("Command: %s", str(command_args))
 
             ### open and log subprocess
-            proc = subprocess.Popen(command_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)     ### start subprocess
+            proc = subprocess.Popen(
+                command_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+            )  ### start subprocess
 
-            for line in proc.stdout.readlines():                                                        ### log with custom level
+            for line in proc.stdout.readlines():  ### log with custom level
                 logging.subprocess(line.decode().strip())
-
 
             logging.warning("end")
             self.procList.append(proc)

--- a/postprocessing/Consumer.py
+++ b/postprocessing/Consumer.py
@@ -112,7 +112,14 @@ class Listener(stomp.ConnectionListener):
             command_args.append(str(data).replace(" ", ""))
 
             logging.warning("Command: %s", str(command_args))
-            proc = subprocess.Popen(command_args)
+
+            ### open and log subprocess
+            proc = subprocess.Popen(command_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)     ### start subprocess
+
+            for line in proc.stdout.readlines():                                                        ### log with custom level
+                logging.subprocess(line.decode().strip())
+
+
             logging.warning("end")
             self.procList.append(proc)
             if instrument is not None:

--- a/postprocessing/PostProcessAdmin.py
+++ b/postprocessing/PostProcessAdmin.py
@@ -58,6 +58,8 @@ if __name__ == "__main__":
     import argparse
     from postprocessing.Configuration import read_configuration
 
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s/%(process)d %(message)s")
+
     parser = argparse.ArgumentParser(description="Post-processing agent")
     parser.add_argument(
         "-q", metavar="queue", help="ActiveMQ queue name", dest="queue", required=True

--- a/postprocessing/PostProcessAdmin.py
+++ b/postprocessing/PostProcessAdmin.py
@@ -58,7 +58,9 @@ if __name__ == "__main__":
     import argparse
     from postprocessing.Configuration import read_configuration
 
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s/%(process)d %(message)s")
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s/%(process)d %(message)s"
+    )
 
     parser = argparse.ArgumentParser(description="Post-processing agent")
     parser.add_argument(


### PR DESCRIPTION
Logging from PostProcessAdmin was not being captured because it is ran as a subprocess from Consumer

Adds a custom logging level "subprocess" and logs PostProcessAdmin output

[3319: [Defect] Indirect Data Analysis Plot not working in Mantid nightly](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/3319)