### PR TITLE
Make 'processors' an optional configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For the old version of the post-processing agent, see https://github.com/mantidp
 
 Configuration
 -------------
-A configuration must be placed in `/etc/post_process_consumer.conf`.
+A configuration must be placed in `/etc/autoreduce/post_processing.conf`.
 
 The `configuration/post_process_consumer.conf.development` file will make a good starting
 point for configuration. Here are the entries to pay attention to:
@@ -33,7 +33,7 @@ point for configuration. Here are the entries to pay attention to:
 
 #### ActiveMQ settings
 
-   - The ActiveMQ server settings must be set by replacing localhost above
+   - The ActiveMQ server settings must be set by replacing `localhost` above
      by the proper address and the `"amq_user"` and `"amq_pwd"` must be filled out.
 
    - If `"jobs_per_instrument"` is set to an integer greater than zero, no more than
@@ -77,32 +77,23 @@ calling scripts hosted on the analysis cluster.
 
 Installation
 ------------
-The typical installation is designed to be similar to earlier versions of this service.
-You can modify where the software is installed by modifying the prefix at the top of the Makefile.
 
-   - Create the configuration files:
+Create the configuration files and edit according to your installation.
 
     cd configuration
-    cp post_process_consumer.conf.developement post_process_consumer.conf
+    cp post_process_consumer.conf.developement /etc/autoreduce/post_processing.conf
 
-   Edit the file according to your installation.
-
-   - From the top source directory, run
-
-    sudo make install
-
-   - Alternatively, you can package your configured installation as an RPM:
-
-    make rpm
-
-   - To install on a compute node with limited access, you can also do the following:
-
-    sudo make install/isolated
-
-   - To run, simply call
+To run, simply call
 
     python [installation path]/queueProcessor.py
 
+Development environment
+-----------------------
+
+The conda environment for running `queueProcessor.py` and tests locally is defined in `environment.yml`. Create and activate the conda environment for development.
+
+    conda env create  # or: mamba env create
+    conda activate post_processing_agent
 
 Running the tests
 -----------------
@@ -141,7 +132,7 @@ or
 
     $ python scripts/mantidpython.py tests/reduce_CONDA.py [Data file]  [Output dir]
 
-as an example for how to activating a specific conda environment for reduction.
+as an example for how to activate a specific conda environment for reduction.
 
 
 Running with docker

--- a/README.md
+++ b/README.md
@@ -12,16 +12,13 @@ Configuration
 -------------
 A configuration must be placed in `/etc/post_process_consumer.conf`.
 
-The `configuration/post_process_consumer.conf.developement` file will make a good starting
+The `configuration/post_process_consumer.conf.development` file will make a good starting
 point for configuration. Here are the entries to pay attention to:
 
     {
-        "uri": "failover:(tcp://localhost:61613)?randomize=false,startupMaxReconnectAttempts=100,initialReconnectDelay=1000,maxReconnectDelay=5000,maxReconnectAttempts=-1",
+        "brokers": [("localhost", 61613)],
         "amq_user": "",
         "amq_pwd": "",
-        "amq_queues": ["/queue/FERMI_REDUCTION.DATA_READY", "/queue/CATALOG.DATA_READY", "/queue/REDUCTION_CATALOG.DATA_READY"],
-        "reduction_data_ready": "FERMI_REDUCTION.DATA_READY",
-
         "sw_dir": "/opt/postprocessing",
         "python_dir": "/opt/postprocessing/postprocessing",
         "start_script": "python",
@@ -37,16 +34,11 @@ point for configuration. Here are the entries to pay attention to:
 #### ActiveMQ settings
 
    - The ActiveMQ server settings must be set by replacing localhost above
-     by the proper address and the "amq_user" and "amq_pwd" must be filled out.
-   - List the input queues in "amq_queues".
-   - Change the input queue names as needed. For example, if the standard
-     "REDUCTION.DATA_READY" queue is replaced by special-purpose queue like
-     "FERMI_REDUCTION.DATA_READY", you should change the name of that queue
-     on the configuration file.
+     by the proper address and the `"amq_user"` and `"amq_pwd"` must be filled out.
 
-   - If "jobs_per_instrument" is set to an integer greater than zero, no more than
+   - If `"jobs_per_instrument"` is set to an integer greater than zero, no more than
       that number of jobs will run on a given node for a given instrument.
-      Set "jobs_per_instrument" to zero to turn this feature off.
+      Set `"jobs_per_instrument"` to zero to turn this feature off.
 
       If this feature is used, you must add the following to activemq.xml:
 

--- a/SPECS/postprocessing.spec
+++ b/SPECS/postprocessing.spec
@@ -3,7 +3,7 @@
 %define release 1
 
 Name: %{srcname}
-Version: 2.8.0
+Version: 3.0.0
 Release: %{release}%{?dist}
 Summary: %{summary}
 

--- a/configuration/post_process_consumer.conf.development
+++ b/configuration/post_process_consumer.conf.development
@@ -1,7 +1,6 @@
 {
     "failover_uri": "failover:(tcp://localhost:61613)?randomize=false,startupMaxReconnectAttempts=100,initialReconnectDelay=1000,maxReconnectDelay=5000,maxReconnectAttempts=-1",
     "brokers": [["localhost", 61613]],
-    "amq_queues": ["/queue/REDUCTION.DATA_READY"],
     "amq_user": "icat",
     "amq_pwd": "icat",
     "sw_dir": "/opt/postprocessing",

--- a/configuration/post_process_consumer.conf.local
+++ b/configuration/post_process_consumer.conf.local
@@ -1,7 +1,6 @@
 {
     "failover_uri": "failover:(tcp://localhost:61613)?randomize=false,startupMaxReconnectAttempts=100,initialReconnectDelay=1000,maxReconnectDelay=5000,maxReconnectAttempts=-1",
     "brokers": [("localhost", 61613)],
-    "amq_queues": ["/queue/REDUCTION.CREATE_SCRIPT", "/queue/REDUCTION.DATA_READY", "/queue/CATALOG.DATA_READY", "/queue/REDUCTION_CATALOG.DATA_READY"],
     "amq_user": "",
     "amq_pwd": "",
     "sw_dir": "/opt/postprocessing",

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: post_processing_agent_py3
+name: post_processing_agent
 channels:
   - conda-forge
   - defaults
@@ -12,5 +12,3 @@ dependencies:
   - requests=2.25
   - stomp.py=7
   - h5py
-# needed for wheel - add when switching to python3
-#  - build

--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,4 @@ dependencies:
   - requests=2.25
   - stomp.py=7
   - h5py
+  - build

--- a/postprocessing/PostProcessAdmin.py
+++ b/postprocessing/PostProcessAdmin.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
                             f"postprocessing.processors.{toks[0]}"
                         )
                         try:
-                            processor_class = eval(f"processor_module.{toks[1]}")
+                            processor_class = getattr(processor_module, toks[1])
                             if (
                                 namespace.queue
                                 == processor_class.get_input_queue_name()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "postprocessing"
 description = "Post-processing agent to automatically catalog and reduce neutron data"
-version = "2.8.0"
+version = "3.0.0"
 requires-python = ">=3.9"
 dependencies = [
     "requests",

--- a/tests/data/post_processing.conf
+++ b/tests/data/post_processing.conf
@@ -1,7 +1,6 @@
 {
     "failover_uri": "failover:(tcp://amqbroker.sns.gov:61613)?randomize=false,startupMaxReconnectAttempts=100,initialReconnectDelay=1000,maxReconnectDelay=5000,maxReconnectAttempts=-1",
     "brokers": [["amqbroker.sns.gov", 61613]],
-    "amq_queues": ["/queue/REDUCTION.CREATE_SCRIPT", "/queue/REDUCTION.DATA_READY", "/queue/CATALOG.DATA_READY"],
     "amq_user": "wfclient",
     "amq_pwd": "w0rkfl0w",
     "sw_dir": "/opt/postprocessing",

--- a/tests/data/post_processing.conf.original
+++ b/tests/data/post_processing.conf.original
@@ -1,6 +1,5 @@
 {
     "failover_uri": "failover:(tcp://amqbroker.sns.gov:61613)?randomize=false,startupMaxReconnectAttempts=100,initialReconnectDelay=1000,maxReconnectDelay=5000,maxReconnectAttempts=-1",
-    "amq_queues": ["/queue/REDUCTION.CREATE_SCRIPT", "/queue/REDUCTION.DATA_READY", "/queue/CATALOG.DATA_READY"],
     "amq_user": "wfclient",
     "amq_pwd": "w0rkfl0w",
     "sw_dir": "/opt/postprocessing",

--- a/tests/integration/post_processing.conf
+++ b/tests/integration/post_processing.conf
@@ -1,7 +1,6 @@
 {
     "failover_uri": "failover:(tcp://activemq:61613)?randomize=false,startupMaxReconnectAttempts=100,initialReconnectDelay=1000,maxReconnectDelay=5000,maxReconnectAttempts=-1",
     "brokers": [["activemq", 61613]],
-    "amq_queues": ["/queue/CATALOG.DATA_READY"],
     "amq_user": "",
     "amq_pwd": "",
     "sw_dir": "/opt/postprocessing",

--- a/tests/unit/postprocessing/test_Configuration.py
+++ b/tests/unit/postprocessing/test_Configuration.py
@@ -27,6 +27,7 @@ class TestConfiguration:
         assert conf.log_file == "/tmp/postprocessing.log"
         assert "/queue/CATALOG.ONCAT.DATA_READY" in conf.queues
         assert sys.path[0] == "/opt/postprocessing"
+        assert len(conf.processors) == 2
 
     def test_log_configuration(self, data_server, test_logger):
         conf = Configuration(data_server.path_to("post_processing.conf"))


### PR DESCRIPTION
# Short description of the changes:
Make `"processors"` an optional configuration parameter. The default is to use all basic post-processors: reduction processor, ONCat processor, ONCat reduced processor, and create reduction script processor.

# Check list for the pull request
- [x] I have read the [CONTRIBUTING]
- [x] I have read the [CODE_OF_CONDUCT]
- [x] I have added tests for my changes
- [x] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
[Defect 3454: [Defect] Update data_workflow to match the changes from post_processing agent](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=3454)