### PR TITLE
Fixup ar_report.py

### DIFF
--- a/scripts/ar_report.py
+++ b/scripts/ar_report.py
@@ -187,6 +187,7 @@ class ReductionLogFile(GenericFile):
 class ARstatus:
     def __init__(self, direc, eventfile):
         self.eventfile = eventfile
+        shareddirlist = os.listdir(direc)
         self.reduxfiles = [
             os.path.join(direc, name)
             for name in shareddirlist
@@ -391,26 +392,27 @@ def main(runfile, outputdir):
         runs = [EventFile(*(os.path.split(runfile)))]
     else:
         runs = getRuns(propdir)
-    reducedir = os.path.join(propdir, "shared", "autoreduce")
 
-    # shareddirlist = os.listdir(reducedir)
-    # reduceloglist = os.listdir(os.path.join(reducedir, REDUCTION_LOG))
+    print(f"Processing {len(runs)} nexus files")
 
     outfile = getOutFilename(propdir)
-
     outfile = os.path.join(outputdir, outfile)
-    print(f"Writing results to '{outfile}'")
+
+    reducedir = os.path.join(propdir, "shared", "autoreduce")
 
     total_runs = len(runs)
     total_reduced = 0
     if runfile is None or (not os.path.exists(outfile)):
+        print(f"Writing results to '{outfile}'")
         mode = "w"
     else:
+        print(f"Appending results to '{outfile}'")
         mode = "a"
     with open(outfile, mode) as handle:
         if mode == "w":
             handle.write(",".join(ARstatus.header()) + "\n")
-        for eventfile in runs:
+        for i, eventfile in enumerate(runs):
+            print("Processing", eventfile, i+1, "of", total_runs)
             ar = ARstatus(reducedir, eventfile)
             report = [str(item) for item in ar.report()]
             if len(ar.reduxfiles) > 0:


### PR DESCRIPTION
`ar_report.py` has various little bugs, key is that it doesn't think that HFIR is a facility at ORNL. This fixes those issues so a report can be generated for a whole proposal of HB2C/WAND.

The details are:
* Allow HFIR proposals as well
* Change timestamps to include seconds
* Fix bug in finding logfiles
* Add progress reporting

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer

To test, on any computer that has the data mount
```sh
$ python3 ar_report.py /HFIR/HB2C/IPTS-31431/ $(pwd)
```

# References

* [EWM4310](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4310)
