### PR TITLE
More timings

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,8 +4,6 @@ coverage:
       default:
         target: 60%
         threshold: 5%
-ignore:
-  - "scripts/ar_report.py"
 
 github_checks:
   annotations: false

--- a/scripts/ar_report.py
+++ b/scripts/ar_report.py
@@ -47,7 +47,7 @@ class GenericFile:
             return self.timeCreation.strftime("%Y-%m-%dT%H:%M")
 
     def filesizeMiB(self):
-        return f"{float(self.filesize) / 1024.0 / 1024.0}"
+        return f"{float(self.filesize) / 1024.0 / 1024.0:.1f}"
 
     def filesizehuman(self):
         if self.filesize < 1024:
@@ -284,6 +284,7 @@ class ARstatus:
             "runID",
             "runStart",
             "runStop",
+            "runDuration",
             "runCTime",
             "eventSizeMiB",
             "host",
@@ -302,6 +303,7 @@ class ARstatus:
             str(self.eventfile),
             self.eventfile.timeStart,
             self.eventfile.timeStop,
+            f"{self.eventfile.duration:.1f}",
             self.eventfile.iso8601(),
             self.eventfile.filesizeMiB(),
             self.host,
@@ -310,9 +312,9 @@ class ARstatus:
             self.logstarted,
             self.logiso8601,
             self.longestAlgorithm,
-            self.longestDuration,
-            self.loadDurationTotal,
-            self.loadEventNexusDuration,
+            f"{self.longestDuration:.1f}",
+            f"{self.loadDurationTotal:.1f}",
+            f"{self.loadEventNexusDuration:.1f}",
         )
 
 
@@ -326,6 +328,7 @@ class EventFile(GenericFile):
             entry = handle.get("entry")
             self.timeStart = entry.get("start_time")[0].decode("utf-8")[:19]
             self.timeStop = entry.get("end_time")[0].decode("utf-8")[:19]
+            self.duration = float(entry.get("duration").value[0])
 
     def __str__(self):
         return self.prefix
@@ -366,8 +369,7 @@ def getRuns(propdir):
 
     # get a list of event files in that directory
     files = os.listdir(datadirs[0])
-    files = [name for name in files if not name.endswith("_histo.nxs")]
-    files = [EventFile(datadirs[0], name) for name in files]
+    files = [EventFile(datadirs[0], name) for name in files if not name.endswith("_histo.nxs")]
 
     return files
 

--- a/scripts/ar_report.py
+++ b/scripts/ar_report.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import h5py
 import os
-import datetime
+from datetime import datetime, timedelta
 
 __version__ = "0.0.1"
 
@@ -25,7 +25,7 @@ class GenericFile:
             return
 
         stat = os.stat(self.filename)
-        self.timeCreation = datetime.datetime.fromtimestamp(stat.st_ctime)
+        self.timeCreation = datetime.fromtimestamp(stat.st_ctime)
         self.filesize = stat.st_size
 
     # called for bool(obj) in python 3.x
@@ -73,6 +73,10 @@ class ReductionLogFile(GenericFile):
         self.longestAlgorithm = "UNKNOWN"
         self.loadDurationTotal = 0.0
         self.loadEventNexusDuration = 0.0
+        self.firstAlgName="UNKNOWN"
+        self.firstAlgStart="UNKNOWN"
+        self.lastAlgName="UNKNOWN"
+        self.lastAlgFinish="UNKNOWN"
         self.started = "UNKNOWN"
         self.host = "UNKNOWN"
 
@@ -83,6 +87,7 @@ class ReductionLogFile(GenericFile):
         self.__findLongestDuration()
         self.__findLoadNexusTotal(eventfilename)
         self.__findLoadTotal()
+        self.__estimateReductionTime()
 
     def durationToHuman(duration):
         (hours, minutes, seconds) = (0.0, 0.0, duration)
@@ -122,6 +127,33 @@ class ReductionLogFile(GenericFile):
                 line = line.strip()
                 (_, duration) = self.logDurationToNameAndSeconds(line)
                 self.loadDurationTotal += duration
+
+    def __estimateReductionTime(self):
+        with open(self.filename, "r") as handle:
+            algName = ''
+            algStart = None
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                if "Execution Date:" in line:
+                    algName = line.split('-')[0]
+
+                    # very convoluted way to get datetime in python 3.6
+                    algStart = line.split('Execution Date:')[-1].strip()
+                    algStart, fraction = algStart.split('.') # strptime doesn't like decimals in seconds
+                    # datetime.fromisoformat isn't available in python3.6
+                    algStart = datetime.strptime(algStart, r"%Y-%m-%d %H:%M:%S")
+                    algStart += timedelta(seconds=float('.'+fraction))
+                    if self.firstAlgName == "UNKNOWN":
+                        self.firstAlgName = algName
+                        self.firstAlgStart = algStart
+                elif self.hasLogDuration(line):
+                    if algName and line.startswith(algName):
+                        self.lastAlgName=algName
+                        (_, duration) = self.logDurationToNameAndSeconds(line)
+                        self.lastAlgFinish = algStart + timedelta(seconds=duration)
+                        algName = '' # clear it out for the next round
 
     @staticmethod
     def hasLogDuration(line):
@@ -278,6 +310,21 @@ class ARstatus:
             total += float(logfile.loadEventNexusDuration)
         return total
 
+    @property
+    def reduxTime(self):
+        '''This estimates the time for autoreduction to be the time between when mantid was first imported and
+        when the last algorithm finished'''
+        logfiles = [logfile for logfile in self.logfiles
+                    if (logfile.firstAlgStart != "UNKNOWN" and logfile.lastAlgFinish != "UNKNOWN")]
+        if len(logfiles) == 0:
+            return 0.
+
+        start = logfiles[0].firstAlgStart
+        finish = logfiles[0].lastAlgFinish
+
+        # calculate and return the duration
+        return (finish-start) / timedelta(seconds=1)
+
     @staticmethod
     def header():
         return (
@@ -296,9 +343,12 @@ class ARstatus:
             "algoSec",
             "loadSecTotal",
             "loadNexusSecTotal",
+            "reduxEstTime",
+            "meas-redux"
         )
 
     def report(self):
+        reduxTime = self.reduxTime
         return (
             str(self.eventfile),
             self.eventfile.timeStart,
@@ -315,6 +365,8 @@ class ARstatus:
             f"{self.longestDuration:.1f}",
             f"{self.loadDurationTotal:.1f}",
             f"{self.loadEventNexusDuration:.1f}",
+            f"{reduxTime:.1f}",
+            f"{self.eventfile.duration-reduxTime:.1f}"
         )
 
 

--- a/scripts/ar_report.py
+++ b/scripts/ar_report.py
@@ -380,7 +380,10 @@ class EventFile(GenericFile):
             entry = handle.get("entry")
             self.timeStart = entry.get("start_time")[0].decode("utf-8")[:19]
             self.timeStop = entry.get("end_time")[0].decode("utf-8")[:19]
-            self.duration = float(entry.get("duration").value[0])
+            try:
+                self.duration = float(entry.get("duration").value[0])
+            except AttributeError:
+                self.duration = float(entry.get("duration")[0])
 
     def __str__(self):
         return self.prefix

--- a/tests/unit/scripts/test_ar_report.py
+++ b/tests/unit/scripts/test_ar_report.py
@@ -23,6 +23,7 @@ ZERO_STR = "0.0"
 def nexus_file():
     start_time = "starting-time"
     end_time = "starting-time"
+    duration = 42.
 
     sns_dir = tempfile.mkdtemp(prefix="SNS")
     instrument_dir = tempfile.mkdtemp(dir=sns_dir)
@@ -45,11 +46,13 @@ def nexus_file():
                 end_time,
             ],
         )
+        entry.create_dataset("duration", (1,), data=[duration])
 
     yield {
         "filepath": Path(nexus_file.name),
         "start_time": start_time,
         "end_time": end_time,
+        "duration": duration,
     }
 
 
@@ -246,6 +249,7 @@ def test_EventFile(nexus_file):
     assert eventfile.isThisRun(str(nexus_file["filepath"].name))
     assert eventfile.timeStart == nexus_file["start_time"]
     assert eventfile.timeStop == nexus_file["end_time"]
+    assert eventfile.duration == nexus_file["duration"]
 
 
 ########################################### unit tests of ARStatus


### PR DESCRIPTION
Since the larger problem with WAND^2 is that the queue is getting full, this add mores metrics which estimate the reduction time. Unfortunately, it is estimating the time for reduction as the difference between when mantid-framework is initialized and the last algorithm ends. Reduction scripts do not have to be written this way, but this gives a minimum time spent running the reduction.

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
