### PR TITLE
Add rotating logs based on filesize

### DIFF
--- a/postprocessing/Configuration.py
+++ b/postprocessing/Configuration.py
@@ -10,6 +10,7 @@ import sys
 import os
 import json
 import logging
+from logging.handlers import RotatingFileHandler
 import importlib
 
 
@@ -218,10 +219,9 @@ def initialize_logging(log_file, level=logging.INFO, preemptive_cleanup=False):
             logging.root.removeHandler(handler)
 
     logging.basicConfig(
+        handlers=[RotatingFileHandler(log_file, maxBytes=10_000_000, backupCount=100)],
         level=level,
         format="%(asctime)s %(levelname)s/%(process)d %(message)s",
-        filename=log_file,
-        filemode="a",
     )
 
     ### add a level for subprocess logging


### PR DESCRIPTION
This switches the logging handler to be [logging.handlers.RotatingFileHandler](https://docs.python.org/3/library/logging.handlers.html#logging.handlers.RotatingFileHandler).

To test, I decreased the `maxBytes` to 10000 and ran the [integration tests](https://github.com/neutrons/post_processing_agent?tab=readme-ov-file#integration-tests) a few times. Before stopping docker I checked that the log files were rotating.

```bash
$ docker exec -it integration_post_processing_agent_1 ls -la /opt/postprocessing/log/
total 76
drwxr-xr-x 1 root root 4096 Apr 30 06:01 .
drwxr-xr-x 1 root root 4096 Apr 30 06:01 ..
-rw-r--r-- 1 root root  965 Apr 30 06:02 postprocessing.log
-rw-r--r-- 1 root root 9919 Apr 30 06:01 postprocessing.log.1
-rw-r--r-- 1 root root 9955 Apr 30 06:01 postprocessing.log.2
-rw-r--r-- 1 root root 9926 Apr 30 06:01 postprocessing.log.3
-rw-r--r-- 1 root root 9848 Apr 30 06:01 postprocessing.log.4
-rw-r--r-- 1 root root 9956 Apr 30 06:00 postprocessing.log.5
```
[EWM4315](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=4315)

There are already tests checking that the log file is generated, I didn't see any need to add additional ones.

# Short description of the changes:
<!-- Add a concise description here-->

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
