### PR TITLE
Job memory monitoring

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,3 +13,4 @@ dependencies:
   - stomp.py=7
   - h5py
   - build
+  - psutil

--- a/postprocessing/Configuration.py
+++ b/postprocessing/Configuration.py
@@ -162,6 +162,10 @@ class Configuration:
                         "Configuration: Processors can only be specified in the format module.Processor_class"
                     )
 
+        # Job memory monitoring
+        self.system_mem_limit_perc = config.get("system_mem_limit_perc", 70.0)
+        self.mem_check_interval_sec = config.get("mem_check_interval_sec", 0.2)
+
     def log_configuration(self, logger=logging):
         """
         Log the current configuration

--- a/postprocessing/Consumer.py
+++ b/postprocessing/Consumer.py
@@ -211,10 +211,15 @@ class Consumer:
         self._connection = None
         self._exit = False
 
+        # Signals registered for systemd
         signal.signal(signal.SIGTERM, self.exit_gracefully)
         signal.signal(signal.SIGINT, self.exit_gracefully)
+        signal.signal(signal.SIGQUIT, self.exit_gracefully)
 
     def exit_gracefully(self, *args):
+        """
+        Tells Consumer to stop listening after current job is finished
+        """
         self._exit = True
 
     def get_connection(self, listener=None):

--- a/postprocessing/processors/job_handling.py
+++ b/postprocessing/processors/job_handling.py
@@ -53,7 +53,7 @@ def local_submission(configuration, script, input_file, output_dir, out_log, out
                     )
                     if total_mem_usage_mb > mem_limit_mb:
                         err_message = f"Total memory usage exceeded limit ({total_mem_usage_mb} MB > {mem_limit_mb} MB). Terminating subprocess and any child processes."
-                        logging.error(err_message)
+                        logging.warning(err_message)
                         # Terminate process and its child processes
                         terminate_or_kill_process_tree(proc.pid)
                         # Add message in the run reduction error log file
@@ -140,7 +140,11 @@ def terminate_or_kill_process_tree(pid, timeout=3):
     """
 
     def on_terminate(proc):
-        logging.warning(f"process {proc} terminated with exit code {proc.returncode}")
+        warn_msg = ""
+        if proc.pid != pid:
+            warn_msg += "child "
+        warn_msg += f"process {proc} terminated with exit code {proc.returncode}"
+        logging.warning(warn_msg)
 
     parent = psutil.Process(pid)
     procs = parent.children(recursive=True)

--- a/postprocessing/processors/job_handling.py
+++ b/postprocessing/processors/job_handling.py
@@ -7,6 +7,10 @@ import logging
 import subprocess
 import os
 import re
+import time
+import psutil
+
+CONVERSION_FACTOR_BYTES_TO_MB = 1.0 / (1024 * 1024)
 
 
 def local_submission(configuration, script, input_file, output_dir, out_log, out_err):
@@ -25,6 +29,8 @@ def local_submission(configuration, script, input_file, output_dir, out_log, out
         input_file,
         output_dir,
     )
+    # Get process memory usage limit
+    mem_limit_mb = get_memory_limit_mb(configuration)
     with open(out_log, "w") as logFile, open(out_err, "w") as errFile:
         if configuration.comm_only is False:
             proc = subprocess.Popen(
@@ -36,7 +42,35 @@ def local_submission(configuration, script, input_file, output_dir, out_log, out
                 universal_newlines=True,
                 cwd=output_dir,
             )
-            proc.communicate()
+            proc_psutil = psutil.Process(proc.pid)
+
+            # Monitor the total memory usage of the subprocess and its children
+            try:
+                while proc.poll() is None:  # process is still running
+                    total_mem_usage_mb = (
+                        get_total_memory_usage(proc_psutil)
+                        * CONVERSION_FACTOR_BYTES_TO_MB
+                    )
+                    if total_mem_usage_mb > mem_limit_mb:
+                        err_message = f"Total memory usage exceeded limit ({total_mem_usage_mb} MB > {mem_limit_mb} MB). Terminating subprocess and any child processes."
+                        logging.error(err_message)
+                        # Terminate process and its child processes
+                        terminate_or_kill_process_tree(proc.pid)
+                        # Add message in the run reduction error log file
+                        errFile.write(err_message)
+
+                    time.sleep(configuration.mem_check_interval_sec)
+
+                proc.wait()
+
+            except psutil.NoSuchProcess:
+                logging.warning("The process has already terminated.")
+
+            except Exception as e:
+                logging.error(f"An error occurred: {e}")
+
+            finally:
+                proc.communicate()
 
 
 def determine_success_local(configuration, out_err):
@@ -72,3 +106,56 @@ def determine_success_local(configuration, out_err):
             data["error"] = f"REDUCTION: {error_line}"
 
     return success, data
+
+
+def get_memory_limit_mb(configuration):
+    """
+    Get the memory limit in Megabytes based on a percentage of the available system memory
+    @param Configuration configuration: configuration
+    @return float: memory limit in MB
+    """
+    mem_total = psutil.virtual_memory().total
+    mem_percentage = configuration.system_mem_limit_perc
+    return mem_total * mem_percentage * CONVERSION_FACTOR_BYTES_TO_MB
+
+
+def get_total_memory_usage(proc):
+    """
+    Get the total memory usage in bytes of process ``proc`` and its children
+    @param Popen proc: process
+    @return float: memory usage in bytes
+    """
+    # Start with the memory usage of the parent process
+    total_memory = proc.memory_info().rss
+    # Iterate through all child processes and add their memory usage
+    for child in proc.children(recursive=True):
+        total_memory += child.memory_info().rss
+    return total_memory
+
+
+def terminate_or_kill_process_tree(pid, timeout=3):
+    """Terminate or, if unsuccessful, kill process and its children
+    @param int pid: process ID
+    @param int timeout: timeout in seconds
+    """
+
+    def on_terminate(proc):
+        logging.warning(f"process {proc} terminated with exit code {proc.returncode}")
+
+    parent = psutil.Process(pid)
+    procs = parent.children(recursive=True)
+    procs.append(parent)
+    # Send SIGTERM
+    for p in procs:
+        p.terminate()
+    gone, alive = psutil.wait_procs(procs, timeout=timeout, callback=on_terminate)
+    if alive:
+        # Send SIGKILL
+        for p in alive:
+            logging.warning(f"process {p} survived SIGTERM; trying SIGKILL")
+            p.kill()
+        gone, alive = psutil.wait_procs(alive, timeout=timeout, callback=on_terminate)
+        if alive:
+            # Give up
+            for p in alive:
+                logging.warning(f"process {p} survived SIGKILL; giving up")

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi
 
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
-RUN dnf install -y python3-requests python3-stomppy python3-pip python3-coverage python-unversioned-command
+RUN dnf install -y python3-requests python3-stomppy python3-pip python3-coverage python3-psutil python-unversioned-command
 
 COPY postprocessing /opt/postprocessing/postprocessing
 COPY tests/integration/post_processing.conf /etc/autoreduce/post_processing.conf


### PR DESCRIPTION
# Short description of the changes:
- add job memory monitoring and terminate processes that exceed a configurable percentage of the system memory
- add systemd service file and include in RPM

# Long description of the changes:
We have seen several cases of the Post-processing Agent being killed (and automatically restarted) when a subprocess reduction job used too much memory, causing the Out Of Memory (OOM) killer to kill the subprocess and main process with signal SIGKILL. This change is to prevent the Post-processing Agent from being killed by a rogue reduction job by monitoring the total memory usage of the subprocess and its children and terminating them when the memory usage exceeds some percentage of the system memory.

# Check list for the pull request
- [x] I have read the [CONTRIBUTING]
- [x] I have read the [CODE_OF_CONDUCT]
- [x] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
[Defect 6664: [AR] Investigate How to Prevent the Crashing of postprocessingagent](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=6664)
