### PR TITLE
Change docker-compose to docker compose

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -52,7 +52,7 @@ jobs:
         cache-environment: true
 
     - name: Start docker containers
-      run: docker-compose -f tests/integration/docker-compose.yml up --build -d
+      run: docker compose -f tests/integration/docker-compose.yml up --build -d
 
     - name: Sleep, wait for containers to start up
       run: sleep 2
@@ -63,10 +63,10 @@ jobs:
 
     - name: Stop but dont remove docker containers
       # Stopping the containers allows the code coverage to be written to disk
-      run: docker-compose -f tests/integration/docker-compose.yml stop
+      run: docker compose -f tests/integration/docker-compose.yml stop
 
     - name: Copy code coverage out of docker container
-      run: docker cp integration_post_processing_agent_1:/opt/postprocessing/ /tmp/
+      run: docker cp integration-post_processing_agent-1:/opt/postprocessing/ /tmp/
 
     - name: Combine and show code coverage
       shell: bash -l {0}
@@ -79,7 +79,7 @@ jobs:
 
     - name: Bring down docker containers completely now
       # This will completely remove the containers
-      run: docker-compose -f tests/integration/docker-compose.yml down
+      run: docker compose -f tests/integration/docker-compose.yml down
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
@@ -117,7 +117,7 @@ jobs:
         cache-environment: true
 
     - name: Start docker containers
-      run: docker-compose -f tests/integration/docker-compose-rpm.yml up --build -d
+      run: docker compose -f tests/integration/docker-compose-rpm.yml up --build -d
 
     - name: Sleep, wait for containers to start up
       run: sleep 2
@@ -127,4 +127,4 @@ jobs:
       run: python -m pytest -k "test_heartbeat or test_missing_data"
 
     - name: Bring down docker containers
-      run: docker-compose -f tests/integration/docker-compose-rpm.yml down
+      run: docker compose -f tests/integration/docker-compose-rpm.yml down

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Specifying a regular expression using ``-k`` will select all tests that match th
 
 The integration tests requires activemq and the queueprocessor to be running, they will be automatically skipped if activemq is not running. This can be achieved using the docker-compose file provided,
 
-    docker-compose -f tests/integration/docker-compose.yml up -d --build
+    docker compose -f tests/integration/docker-compose.yml up -d --build
 
 then run
 
@@ -118,7 +118,7 @@ then run
 
 after which you can stop docker with
 
-    docker-compose -f tests/integration/docker-compose.yml down
+    docker compose -f tests/integration/docker-compose.yml down
 
 
 Running manual tests for mantidpython.py
@@ -142,3 +142,12 @@ Running with docker
 docker build --tag postprocessing .
 docker run --network host postprocessing
 ```
+
+Creating a new release
+----------------------
+1. Update the version number in [SPECS/postprocessing.spec](SPECS/postprocessing.spec) and
+   [pyproject.toml](pyproject.toml) and commit the change to `main`.
+2. Create a new tag and create a release from the tag (see the three dots menu
+   for the tag at https://github.com/neutrons/post_processing_agent/tags).
+3. Build the RPM using [rpmbuild.sh](rpmbuild.sh) and upload the `.rpm` and `.srpm` files as release
+   assets to the GitHub release page.

--- a/tests/integration/docker-compose-rpm.yml
+++ b/tests/integration/docker-compose-rpm.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
 
   post_processing_agent:

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
 
   post_processing_agent:


### PR DESCRIPTION
# Short description of the changes:
The GitHub runners are now using docker compose v2, which means we need to use `docker compose` instead of `docker-compose` and update the generated container names.

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [x] I have read the [CONTRIBUTING]
- [x] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [x] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
