### PR TITLE
Add systemd service file to RPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY rpmbuild.sh /app/
 COPY README.md /app/
 COPY LICENSE.rst /app/
 COPY SPECS /app/SPECS
+COPY systemd /app/systemd
 
 RUN mkdir -p /root/rpmbuild/SOURCES
 
@@ -18,7 +19,7 @@ RUN cd /app && ./rpmbuild.sh || exit 1
 
 RUN dnf install -y /root/rpmbuild/RPMS/noarch/postprocessing*.noarch.rpm || exit 1
 
-# This configuration allows it to run with docker-compose from https://github.com/neutrons/data_workflow
+# This configuration allows it to run with docker compose from https://github.com/neutrons/data_workflow
 COPY configuration/post_process_consumer.conf.development /etc/autoreduce/post_processing.conf
 RUN sed -i 's/localhost/activemq/' /etc/autoreduce/post_processing.conf
 

--- a/SPECS/postprocessing.spec
+++ b/SPECS/postprocessing.spec
@@ -3,7 +3,7 @@
 %define release 1
 
 Name: %{srcname}
-Version: 3.2.0
+Version: 3.3.0
 Release: %{release}%{?dist}
 Summary: %{summary}
 
@@ -14,11 +14,16 @@ Group: Applications/Engineering
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 BuildArch: noarch
+
 BuildRequires:  python%{python3_pkgversion}-pip
+BuildRequires: systemd-rpm-macros
+
 Requires: python%{python3_pkgversion}
+Requires: python%{python3_pkgversion}-psutil
 Requires: python%{python3_pkgversion}-requests
 Requires: python%{python3_pkgversion}-stomppy
 Requires: python-unversioned-command
+Requires: systemd
 
 prefix: /opt/postprocessing
 
@@ -31,20 +36,23 @@ Post-processing agent to automatically catalog and reduce neutron data
 %autosetup -p1 -n %{srcname}-%{version}
 
 %build
+# no build step
 
 %install
 %{python3} -m pip install --target %{buildroot}%{prefix} --no-deps .
-mv %{buildroot}%{prefix}/postprocessing/queueProcessor.py %{buildroot}%{prefix}
-mkdir -p %{buildroot}%{prefix}/log
-mkdir -p %{buildroot}%{site_packages}
+%{__install} -m 755 %{buildroot}%{prefix}/postprocessing/queueProcessor.py %{buildroot}%{prefix}
+%{__mkdir} -p %{buildroot}%{prefix}/log
+%{__mkdir} -p %{buildroot}%{site_packages}
 echo %{prefix} > %{buildroot}%{site_packages}/postprocessing.pth
-mkdir -p %{buildroot}/var/log/SNS_applications
+%{__mkdir} -p %{buildroot}/var/log/SNS_applications
+%{__mkdir} -p %{buildroot}%{_unitdir}/
+%{__install} -m 644 %{_sourcedir}/autoreduce-queue-processor.service %{buildroot}%{_unitdir}/
 
 %files
 %doc README.md
 %license LICENSE.rst
 %{prefix}/*
 %attr(755, -, -) %{prefix}/scripts
-%attr(755, -, -) %{prefix}/queueProcessor.py
 %{site_packages}/postprocessing.pth
 /var/log/SNS_applications
+%{_unitdir}/autoreduce-queue-processor.service

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "postprocessing"
 description = "Post-processing agent to automatically catalog and reduce neutron data"
-version = "3.2.0"
+version = "3.3.0"
 requires-python = ">=3.9"
 dependencies = [
     "requests",

--- a/rpmbuild.sh
+++ b/rpmbuild.sh
@@ -2,6 +2,7 @@
 rm -rf dist postprocessing.egg-info
 python3 -m build --sdist
 cp dist/postprocessing-*.tar.gz ~/rpmbuild/SOURCES/
+cp systemd/autoreduce-queue-processor.service ~/rpmbuild/SOURCES/
 rpmbuild -ba SPECS/postprocessing.spec
 cp ~/rpmbuild/RPMS/noarch/postprocessing-*-*.*.noarch.rpm dist/
 cp ~/rpmbuild/SRPMS/postprocessing-*-*.*.src.rpm dist/

--- a/systemd/autoreduce-queue-processor.service
+++ b/systemd/autoreduce-queue-processor.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Postprocessing service
+
+[Service]
+WorkingDirectory=/opt/postprocessing
+User=snsdata
+Restart=on-failure
+RestartSec=5s
+ExecStart=/usr/bin/python queueProcessor.py
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# Short description of the changes:
Add the systemd service file to the RPM. This ensures consistency in how Post-processing agent runs on the autoreducers.

# Check list for the pull request
- [x] I have read the [CONTRIBUTING]
- [x] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
