### PR TITLE
Convert memory limit percentage to fraction

### DIFF
--- a/postprocessing/Configuration.py
+++ b/postprocessing/Configuration.py
@@ -69,6 +69,8 @@ class Configuration:
         self.log_file = (
             config["log_file"] if "log_file" in config else "post_processing.log"
         )
+        # log levels: DEBUG, INFO, WARNING, ERROR, CRITICAL
+        self.log_level = getattr(logging, config.get("log_level", ""), logging.INFO)
         self.start_script = (
             config["start_script"] if "start_script" in config else "python"
         )
@@ -287,6 +289,6 @@ def read_configuration(
     configuration = Configuration(config_file)
     if log_file:
         configuration.log_file = str(log_file)
-    initialize_logging(configuration.log_file)
+    initialize_logging(configuration.log_file, configuration.log_level)
 
     return configuration

--- a/postprocessing/processors/job_handling.py
+++ b/postprocessing/processors/job_handling.py
@@ -51,8 +51,11 @@ def local_submission(configuration, script, input_file, output_dir, out_log, out
                         get_total_memory_usage(proc_psutil)
                         * CONVERSION_FACTOR_BYTES_TO_MB
                     )
+                    logging.debug(
+                        f"Subprocess memory usage: {total_mem_usage_mb} MiB. Max limit: {mem_limit_mb} MiB."
+                    )
                     if total_mem_usage_mb > mem_limit_mb:
-                        err_message = f"Total memory usage exceeded limit ({total_mem_usage_mb} MB > {mem_limit_mb} MB). Terminating subprocess and any child processes."
+                        err_message = f"Total memory usage exceeded limit ({total_mem_usage_mb} MiB > {mem_limit_mb} MiB). Terminating subprocess and any child processes."
                         logging.warning(err_message)
                         # Terminate process and its child processes
                         terminate_or_kill_process_tree(proc.pid)
@@ -115,8 +118,8 @@ def get_memory_limit_mb(configuration):
     @return float: memory limit in MB
     """
     mem_total = psutil.virtual_memory().total
-    mem_percentage = configuration.system_mem_limit_perc
-    return mem_total * mem_percentage * CONVERSION_FACTOR_BYTES_TO_MB
+    mem_fraction = configuration.system_mem_limit_perc / 100.0
+    return mem_total * mem_fraction * CONVERSION_FACTOR_BYTES_TO_MB
 
 
 def get_total_memory_usage(proc):


### PR DESCRIPTION
# Short description of the changes:
Fix bug and add more logging for the subprocess memory monitoring introduced in #47
- the memory max limit was too high by a factor 100 since the percentage needs to be converted to a fraction
- add debug log to output the subprocess memory usage in the while loop where memory monitoring happens
- add ability to set logging level from configuration file

# Check list for the pull request
- [x] I have read the [CONTRIBUTING]
- [x] I have read the [CODE_OF_CONDUCT]
- [x] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
[Story 6664: [AR] Investigate How to Prevent the OOM Killer from Killing Post-processing Agent](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=6664)
