### PR TITLE
Change the job queue ActiveMQ prefetch size to get better load balancing

### DIFF
--- a/postprocessing/Consumer.py
+++ b/postprocessing/Consumer.py
@@ -250,7 +250,12 @@ class Consumer:
                 self.config.queues.append(self.config.heartbeat_ping)
 
         for q in self.config.queues:
-            self._connection.subscribe(destination=q, id=q, ack="client")
+            # set prefetchSize to 1 to only prefetch one message at a time (default is 1000)
+            # prefetching a large number of messages prevents effective load balancing
+            # https://activemq.apache.org/components/classic/documentation/what-is-the-prefetch-limit-for
+            self._connection.subscribe(
+                destination=q, id=q, ack="client", headers={"activemq.prefetchSize": 1}
+            )
 
     def _disconnect(self):
         """


### PR DESCRIPTION
# Short description of the changes:

The default queue prefetch size is 1000, which means that consumers can "prefetch" up to 1000 messages from the queues. This is not optimal when messages/jobs can take a long time to process, since it prevents good load balancing between the consumers/autoreducers. Change the prefetch size to 1 to allow for better load balancing.

From the [ActiveMQ Classic documentation](https://activemq.apache.org/components/classic/documentation/what-is-the-prefetch-limit-for):

> Large prefetch values are recommended for high performance with high message volumes. However, for lower message volumes, where each message takes a long time to process, the prefetch should be set to 1. This ensures that a consumer is only processing one message at a time. Specifying a prefetch limit of zero, however, will cause the consumer to poll for messages, one at a time, instead of the message being pushed to the consumer.

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
