### PR TITLE
Fix the owner of the logging directory created by the RPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ COPY systemd /app/systemd
 
 RUN mkdir -p /root/rpmbuild/SOURCES
 
+# The RPM build assumes that user "snsdata" and group "snswheel" exist
+RUN useradd snsdata
+RUN groupadd snswheel
+
 RUN cd /app && ./rpmbuild.sh || exit 1
 
 RUN dnf install -y /root/rpmbuild/RPMS/noarch/postprocessing*.noarch.rpm || exit 1

--- a/SPECS/postprocessing.spec
+++ b/SPECS/postprocessing.spec
@@ -44,7 +44,8 @@ Post-processing agent to automatically catalog and reduce neutron data
 %{__mkdir} -p %{buildroot}%{prefix}/log
 %{__mkdir} -p %{buildroot}%{site_packages}
 echo %{prefix} > %{buildroot}%{site_packages}/postprocessing.pth
-%{__mkdir} -p %{buildroot}/var/log/SNS_applications
+%{__mkdir} -p -m 1755 %{buildroot}/var/log/SNS_applications/
+%{__chown} snsdata:snswheel %{buildroot}/var/log/SNS_applications/
 %{__mkdir} -p %{buildroot}%{_unitdir}/
 %{__install} -m 644 %{_sourcedir}/autoreduce-queue-processor.service %{buildroot}%{_unitdir}/
 


### PR DESCRIPTION
# Short description of the changes:
Installing the RPM changes the owner of the logging directory `/var/log/SNS_applications` to `root`, but Post-Processing Agent is started as the user `snsdata`. Change the owner of the directory so Post-Processing Agent is allowed to write logs to it.

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
