### PR TITLE
Log dir chown should use group users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN mkdir -p /root/rpmbuild/SOURCES
 
 # The RPM build assumes that user "snsdata" and group "users" exist
 RUN useradd snsdata
-RUN groupadd users
+# add group "users" only if it doesn't exist
+RUN getent group users || groupadd users
 
 RUN cd /app && ./rpmbuild.sh || exit 1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ COPY systemd /app/systemd
 
 RUN mkdir -p /root/rpmbuild/SOURCES
 
-# The RPM build assumes that user "snsdata" and group "snswheel" exist
+# The RPM build assumes that user "snsdata" and group "users" exist
 RUN useradd snsdata
-RUN groupadd snswheel
+RUN groupadd users
 
 RUN cd /app && ./rpmbuild.sh || exit 1
 

--- a/SPECS/postprocessing.spec
+++ b/SPECS/postprocessing.spec
@@ -45,7 +45,7 @@ Post-processing agent to automatically catalog and reduce neutron data
 %{__mkdir} -p %{buildroot}%{site_packages}
 echo %{prefix} > %{buildroot}%{site_packages}/postprocessing.pth
 %{__mkdir} -p -m 1755 %{buildroot}/var/log/SNS_applications/
-%{__chown} snsdata:snswheel %{buildroot}/var/log/SNS_applications/
+%{__chown} snsdata:users %{buildroot}/var/log/SNS_applications/
 %{__mkdir} -p %{buildroot}%{_unitdir}/
 %{__install} -m 644 %{_sourcedir}/autoreduce-queue-processor.service %{buildroot}%{_unitdir}/
 

--- a/SPECS/postprocessing.spec
+++ b/SPECS/postprocessing.spec
@@ -3,7 +3,7 @@
 %define release 1
 
 Name: %{srcname}
-Version: 3.4.0
+Version: 3.4.1
 Release: %{release}%{?dist}
 Summary: %{summary}
 
@@ -46,6 +46,7 @@ Post-processing agent to automatically catalog and reduce neutron data
 echo %{prefix} > %{buildroot}%{site_packages}/postprocessing.pth
 %{__mkdir} -p -m 1755 %{buildroot}/var/log/SNS_applications/
 %{__chown} snsdata:users %{buildroot}/var/log/SNS_applications/
+%{__chmod} 1755 %{buildroot}/var/log/SNS_applications/
 %{__mkdir} -p %{buildroot}%{_unitdir}/
 %{__install} -m 644 %{_sourcedir}/autoreduce-queue-processor.service %{buildroot}%{_unitdir}/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "postprocessing"
 description = "Post-processing agent to automatically catalog and reduce neutron data"
-version = "3.4.0"
+version = "3.4.1"
 requires-python = ">=3.9"
 dependencies = [
     "requests",


### PR DESCRIPTION
# Short description of the changes:

The group `snswheel` does not exist anymore on the autoreducers, which caused the RPM install `chown` command for the log directory to fail and the owner being set to `root`. This led to Post-Processing Agent failing when log rotation was triggered. In response to this issue, the sysadmins have change the puppet config to set the log directory owner through puppet, but the RPM install will change the owner to `root` (temporarily, until puppet changes it back) unless we use `chown` to set the correct user and group during install.

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
[Defect 9689: [post-processing agent] Log directory owner not set correctly](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9689)
