### PR TITLE
Fix: Set correct owner and permissions for /var/log/SNS_applications in RPM

### DIFF
--- a/SPECS/postprocessing.spec
+++ b/SPECS/postprocessing.spec
@@ -54,7 +54,7 @@ echo %{prefix} > %{buildroot}%{site_packages}/postprocessing.pth
 %doc README.md
 %license LICENSE.rst
 %{prefix}/*
-%attr(755, -, -) %{prefix}/scripts
+%attr(0755, -, -) %{prefix}/scripts
 %{site_packages}/postprocessing.pth
-/var/log/SNS_applications
+%attr(1755, snsdata, users) /var/log/SNS_applications
 %{_unitdir}/autoreduce-queue-processor.service


### PR DESCRIPTION
# Short description of the changes:
Ensures the `/var/log/SNS_applications` directory is owned by `snsdata:users` with `1755` permissions after RPM installation by using the `%attr` directive in the SPEC file. This resolves an issue where the directory ownership could default to root, causing potential log rotation failures.

# Long description of the changes:
The previous RPM SPEC file created the `/var/log/SNS_applications` directory and attempted to set its ownership and permissions during the `%install` phase. However, without an explicit `%attr` directive in the `%files` section for this directory, the RPM could default its ownership to `root:root` upon installation on a target system.

This change modifies `SPECS/postprocessing.spec` to include:
`%attr(1755, snsdata, users) /var/log/SNS_applications`

This directly instructs the RPM to set the owner to `snsdata`, group to `users`, and permissions to `1755` (rwxr-xr-t) for the `/var/log/SNS_applications` directory upon installation. This is the standard and most reliable method to ensure correct file attributes are applied by RPM.

A minor correction was also made to use `0755` instead of `755` for script permissions for explicitness, though this does not change behavior on most systems.

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [x] I have added tests for my changes (Verified via Docker build and inspection as per issue)
- [ ] I have updated the documentation accordingly (No documentation changes needed for this fix)

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
1.  Build the Docker image using the `Dockerfile` in the root of the repository:
    ```bash
    docker build -t postprocessing-rpm-test .
    ```
2.  After the image is built, run a container and inspect the ownership and permissions of the `/var/log/SNS_applications` directory:
    ```bash
    docker run --rm postprocessing-rpm-test ls -ld /var/log/SNS_applications
    ```
3.  Verify that the output shows `snsdata` as the owner and `users` as the group, with permissions `drwxr-xr-t`. Example:
    ```
    drwxr-xr-t X snsdata users XXXX Date Time /var/log/SNS_applications
    ```
    (The `X` and `XXXX Date Time` will vary)

# References
- Related to GitHub Issue/PR (Reopened defect): https://github.com/neutrons/post_processing_agent/pull/62