### PR TITLE
Start the autoreducer service after the SSSD service

### DIFF
--- a/systemd/autoreduce-queue-processor.service
+++ b/systemd/autoreduce-queue-processor.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Postprocessing service
+Requires=sssd.service
+After=sssd.service
 
 [Service]
 WorkingDirectory=/opt/postprocessing


### PR DESCRIPTION
# Short description of the changes:

There is an intermittent problem with autoreducers getting permission denied when trying to open files under the `/HFIR` mount, which have different groups than files under `/SNS`. It was found that the autoreducer python process did not have all the groups it was supposed to have through the user running the process, because it was started before the SSSD service that handles remote authentication had retrieved and initialized the users and credentials.

To resolve the SSSD issues, update the systemd service file to make the service require the SSSD service that handles remote authentication.

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
[Defect 11975: [post-processing agent] Permission denied to HFIR files](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=11975)
