### PR TITLE
Filter image files by run number in VENUS image cataloging

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,14 @@ as an array.
 
 The value found at a metadata path may be either a single image file or a directory holding a whole
 series of images, depending on the detector. In both cases the agent catalogs only the image files
-belonging to the run being cataloged, identified by the file name prefix the VENUS DAQ writes for
-every detector:
+belonging to the run being cataloged, identified by the run number token the VENUS DAQ writes into
+every image file name:
 
-    YYYYMMDD_Run_<run_number>_...
+    Run_<run_number>
+
+Most detectors write it after a date, as `YYYYMMDD_Run_<run_number>_...`, but TPX3 prepends a second
+date (`20250428_20260310_Run_15395_...`), so the token is matched wherever it appears in the name
+rather than only at the start.
 
 Filtering by run number matters because consecutive runs of a series share one image directory: without
 it, each run re-catalogs every image written by the runs before it, which grows with the length of the

--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ If not specified, this defaults to the VENUS instrument metadata path. For other
 this parameter to match the appropriate metadata path(s) in your NeXus files. Multiple paths can be specified
 as an array.
 
+The value found at a metadata path may be either a single image file or a directory holding a whole
+series of images, depending on the detector. In both cases the agent catalogs only the image files
+belonging to the run being cataloged, identified by the file name prefix the VENUS DAQ writes for
+every detector:
+
+    YYYYMMDD_Run_<run_number>_...
+
+Filtering by run number matters because consecutive runs of a series share one image directory: without
+it, each run re-catalogs every image written by the runs before it, which grows with the length of the
+series and can back up the shared autoreducers. Image files whose names do not carry the current run
+number are skipped, and the number skipped is written to the agent log.
+
 ###### Enabling and disabling image cataloging
 
 Image cataloging can be dynamically enabled or disabled per instrument, without a code change,

--- a/README_developer.md
+++ b/README_developer.md
@@ -136,6 +136,15 @@ Queue name: `CATALOG.ONCAT.DATA_READY`.
 
 Cataloging ingests the raw data file and any related files. For instruments that produce image files
 (currently VENUS), an additional image-cataloging substep batch-ingests the associated FITS/TIFF files.
+
+The locations to catalog come from the `image_filepath_metadata_paths` metadata of the ingested
+datafile. A location is either a single image file or a directory of images (`_image_files_at()`
+handles both), and a single metadata path can report several locations: MCP TPX1 runs report both this
+run's directory and the previous run's. Every candidate is filtered through `matches_run_number()`,
+which matches the `YYYYMMDD_Run_<run_number>_` file name prefix the DAQ writes for all VENUS detectors.
+The run number must be followed by a non-digit, so that run 2482 does not claim the images of runs
+24820-24829. Duplicate locations are ingested only once.
+
 This substep is gated per instrument: `ONCatProcessor.catalog_images()` runs only when the script
 `/<facility>/<instrument>/shared/autoreduce/catalog_<INSTRUMENT>.py` exists, mirroring the
 `reduce_<INSTRUMENT>.py` toggle used for autoreduction. The `dev_instrument_shared` configuration

--- a/README_developer.md
+++ b/README_developer.md
@@ -141,9 +141,15 @@ The locations to catalog come from the `image_filepath_metadata_paths` metadata 
 datafile. A location is either a single image file or a directory of images (`_image_files_at()`
 handles both), and a single metadata path can report several locations: MCP TPX1 runs report both this
 run's directory and the previous run's. Every candidate is filtered through `matches_run_number()`,
-which matches the `YYYYMMDD_Run_<run_number>_` file name prefix the DAQ writes for all VENUS detectors.
-The run number must be followed by a non-digit, so that run 2482 does not claim the images of runs
-24820-24829. Duplicate locations are ingested only once.
+which matches the `Run_<run_number>` token the DAQ writes into every image file name. The token is
+matched wherever it appears rather than only at the start, because its position varies by detector: most
+write `YYYYMMDD_Run_<run>_...`, TPX3 prepends a second date (`20250428_20260310_Run_15395_...`), and some
+2025 TPX1 data leads with `Run_<run>_YYYYMMDD_...`. Anchoring to the start would silently catalog nothing
+for the detectors that deviate, which is why the token is matched by position-independent search.
+
+The token must start the name or follow an underscore, and the run number must be followed by a non-digit,
+so that run 2482 does not claim the images of runs 24820-24829. Any non-digit ends the token rather than
+specifically an underscore, for the same reason. Duplicate locations are ingested only once.
 
 This substep is gated per instrument: `ONCatProcessor.catalog_images()` runs only when the script
 `/<facility>/<instrument>/shared/autoreduce/catalog_<INSTRUMENT>.py` exists, mirroring the

--- a/postprocessing/processors/oncat_processor.py
+++ b/postprocessing/processors/oncat_processor.py
@@ -153,14 +153,22 @@ def related_files(datafile):
 def matches_run_number(image_file_path, run_number):
     """Whether an image file belongs to the given run.
 
-    The VENUS DAQ writes every image file with a name that begins with
-    ``YYYYMMDD_Run_<run_number>_``, no matter which detector produced it (this
-    has been confirmed for QHY, Andor, TPX1 and MCP TPX1 data). Matching on that
-    prefix is therefore how we tell the images of the run being cataloged apart
-    from the images of the other runs sharing the same directory.
+    The VENUS DAQ identifies the run in the image file name with a ``Run_<run_number>``
+    token, which is how we tell the images of the run being cataloged apart from the
+    images of the other runs sharing the same directory. Where that token sits in the
+    name varies by detector, so match it anywhere rather than anchoring to the start.
+    The three forms seen in production are::
 
-    The run number must be followed by a non-digit, otherwise run 2482 would
-    also claim the images of runs 24820-24829.
+        20260713_Run_24828_long_acq_test_0_282.tiff          QHY, Andor, TPX1
+        20250428_20251120_Run_14810_HDPErpi_Gd_0__0000.tiff  TPX3, two date prefixes
+        Run_8787_20250516_May16_2025_OB_0005_00826.fits      TPX1 raw/ob, run first
+
+    The token must start the name or follow an underscore, and the run number must be
+    followed by a non-digit, otherwise run 2482 would also claim the images of runs
+    24820-24829. Any non-digit ends the token: the names observed all continue with an
+    underscore, but requiring one would mean silently cataloging nothing for a detector
+    that used another separator, which is a worse failure than cataloging a file that
+    carries this run's number.
 
     Args:
         image_file_path: Path to a candidate image file
@@ -175,7 +183,7 @@ def matches_run_number(image_file_path, run_number):
         run_number = str(int(run_number))
 
     file_name = os.path.basename(image_file_path)
-    return re.match(r"\d{8}_Run_" + re.escape(run_number) + r"(?![0-9])", file_name) is not None
+    return re.search(r"(?:^|_)Run_" + re.escape(run_number) + r"(?![0-9])", file_name) is not None
 
 
 def image_files(datafile, metadata_paths, run_number):

--- a/postprocessing/processors/oncat_processor.py
+++ b/postprocessing/processors/oncat_processor.py
@@ -8,12 +8,16 @@ import os
 import logging
 import json
 import glob
+import re
 from .base_processor import BaseProcessor
 import pyoncat
 
 
 # Batch size for image ingestion (must be less than max of 100)
 IMAGE_BATCH_SIZE = 50
+
+# Glob patterns for the image files to catalog
+IMAGE_FILE_PATTERNS = ("*.fits", "*.tiff")
 
 
 class ONCatProcessor(BaseProcessor):
@@ -95,7 +99,8 @@ class ONCatProcessor(BaseProcessor):
             return
 
         logging.info("Image cataloging enabled for %s (found %s)", self.instrument, catalog_script)
-        images = image_files(datafile, self.configuration.image_filepath_metadata_paths)
+        images = image_files(datafile, self.configuration.image_filepath_metadata_paths, self.run_number)
+        logging.info("Cataloging %d image file(s) for run %s", len(images), self.run_number)
         for batch in batches(images, IMAGE_BATCH_SIZE):
             logging.info("Batch ingesting %d image files", len(batch))
             oncat.Datafile.batch(batch)
@@ -145,19 +150,49 @@ def related_files(datafile):
     ]
 
 
-def image_files(datafile, metadata_paths):
-    """Find image files from metadata paths.
+def matches_run_number(image_file_path, run_number):
+    """Whether an image file belongs to the given run.
 
-    Iterates through the configured metadata paths, retrieves values from
-    the datafile metadata, and globs for image files in the discovered
-    subdirectories.
+    The VENUS DAQ writes every image file with a name that begins with
+    ``YYYYMMDD_Run_<run_number>_``, no matter which detector produced it (this
+    has been confirmed for QHY, Andor, TPX1 and MCP TPX1 data). Matching on that
+    prefix is therefore how we tell the images of the run being cataloged apart
+    from the images of the other runs sharing the same directory.
+
+    The run number must be followed by a non-digit, otherwise run 2482 would
+    also claim the images of runs 24820-24829.
+
+    Args:
+        image_file_path: Path to a candidate image file
+        run_number: Run number being cataloged
+
+    Returns:
+        True if the file name identifies it as an image of that run
+    """
+    run_number = str(run_number).strip()
+    # The DAQ writes the run number without zero padding
+    if run_number.isdigit():
+        run_number = str(int(run_number))
+
+    file_name = os.path.basename(image_file_path)
+    return re.match(r"\d{8}_Run_" + re.escape(run_number) + r"(?![0-9])", file_name) is not None
+
+
+def image_files(datafile, metadata_paths, run_number):
+    """Find the image files belonging to a run.
+
+    Iterates through the configured metadata paths and, for each location found
+    in the datafile metadata, collects the image files that belong to the run
+    being cataloged. See ``_image_files_at`` for how a single location is
+    resolved and ``matches_run_number`` for how the files are filtered.
 
     Args:
         datafile: ONCat datafile object with metadata
-        metadata_paths: List of metadata paths to check for image directory locations
+        metadata_paths: List of metadata paths to check for image file locations
+        run_number: Run number being cataloged
 
     Returns:
-        List of absolute paths to image files (FITS and TIFF)
+        List of absolute paths to this run's image files (FITS and TIFF)
     """
     facility = datafile.facility
     instrument = datafile.instrument
@@ -169,16 +204,58 @@ def image_files(datafile, metadata_paths):
         if value is None:
             continue
 
-        subdirs = value if isinstance(value, list) else [value]
+        # A single metadata path can report more than one location, for instance
+        # MCP TPX1 runs report both this run's directory and the previous run's
+        locations = value if isinstance(value, list) else [value]
 
-        for subdir in subdirs:
-            full_path = os.path.join("/", facility, instrument, experiment, subdir)
+        for location in locations:
+            full_path = os.path.join("/", facility, instrument, experiment, location)
+            image_file_paths.extend(_image_files_at(full_path, run_number))
 
-            if not os.path.isdir(full_path):
-                continue
+    # Locations can be reported more than once, so ingest each file only once
+    return list(dict.fromkeys(image_file_paths))
 
-            fits_files = glob.glob(os.path.join(full_path, "*.fits"))
-            tiff_files = glob.glob(os.path.join(full_path, "*.tiff"))
-            image_file_paths.extend(fits_files + tiff_files)
 
-    return image_file_paths
+def _image_files_at(location, run_number):
+    """Return the image files at a single location that belong to a run.
+
+    The image file path recorded by the DAQ is meant to point at an image file,
+    but for several detectors it points at the directory holding a whole series
+    of images instead, and consecutive runs of a series share that directory.
+    Both forms are filtered by run number, so that a run only ever catalogs its
+    own images: cataloging the whole directory was making a run re-catalog every
+    image written by the runs before it, which is slow enough to back up the
+    autoreducers.
+
+    Args:
+        location: Absolute path reported by the image file path metadata
+        run_number: Run number being cataloged
+
+    Returns:
+        List of absolute paths to this run's image files at that location
+    """
+    if os.path.isdir(location):
+        candidates = []
+        for pattern in IMAGE_FILE_PATTERNS:
+            candidates.extend(glob.glob(os.path.join(location, pattern)))
+        # Glob order is arbitrary; keep the batches in a predictable order
+        candidates.sort()
+    elif os.path.isfile(location):
+        candidates = [location]
+    else:
+        logging.warning("Image file location %s is neither a file nor a directory", location)
+        return []
+
+    matching_files = [path for path in candidates if matches_run_number(path, run_number)]
+
+    skipped = len(candidates) - len(matching_files)
+    if skipped > 0:
+        logging.info(
+            "Skipping %d image file(s) in %s belonging to other runs",
+            skipped,
+            location,
+        )
+    if not matching_files:
+        logging.warning("Found no image files for run %s in %s", run_number, location)
+
+    return matching_files

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -54,6 +54,8 @@ RUN mkdir -p /opt/postprocessing/log && \
     touch /SNS/VENUS/IPTS-99999/images/20260721_Run_12345_series_0002.fits && \
     touch /SNS/VENUS/IPTS-99999/images/20260721_Run_12345_series_0003.tiff && \
     touch /SNS/VENUS/IPTS-99999/images/20260721_Run_12347_series_0001.tiff && \
+    # TPX3 prepends a second date, so the run token is not at the start of the name
+    touch /SNS/VENUS/IPTS-99999/images/20250428_20260721_Run_12345_tpx3_0004.tiff && \
     # Images of another run, and a run number that merely extends 12345:
     # neither belongs to run 12345
     touch /SNS/VENUS/IPTS-99999/images/20260721_Run_12344_series_0001.tiff && \

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -47,9 +47,17 @@ RUN mkdir -p /opt/postprocessing/log && \
     mkdir -p /SNS/VENUS/IPTS-99999/images && \
     mkdir -p /SNS/VENUS/IPTS-99999/shared/autoreduce && \
     touch /SNS/VENUS/IPTS-99999/nexus/VENUS_12345.nxs.h5 && \
-    touch /SNS/VENUS/IPTS-99999/images/image_001.fits && \
-    touch /SNS/VENUS/IPTS-99999/images/image_002.fits && \
-    touch /SNS/VENUS/IPTS-99999/images/image_003.tiff && \
+    touch /SNS/VENUS/IPTS-99999/nexus/VENUS_12347.nxs.h5 && \
+    # Image files are named YYYYMMDD_Run_<run_number>_... by the VENUS DAQ.
+    # Runs 12345 and 12347 share this directory, as a series of runs does.
+    touch /SNS/VENUS/IPTS-99999/images/20260721_Run_12345_series_0001.fits && \
+    touch /SNS/VENUS/IPTS-99999/images/20260721_Run_12345_series_0002.fits && \
+    touch /SNS/VENUS/IPTS-99999/images/20260721_Run_12345_series_0003.tiff && \
+    touch /SNS/VENUS/IPTS-99999/images/20260721_Run_12347_series_0001.tiff && \
+    # Images of another run, and a run number that merely extends 12345:
+    # neither belongs to run 12345
+    touch /SNS/VENUS/IPTS-99999/images/20260721_Run_12344_series_0001.tiff && \
+    touch /SNS/VENUS/IPTS-99999/images/20260721_Run_123450_series_0001.tiff && \
     mkdir -p /SNS/VENUS/shared/autoreduce && \
     echo "# image cataloging enabled for VENUS" > /SNS/VENUS/shared/autoreduce/catalog_VENUS.py && \
     \
@@ -57,8 +65,8 @@ RUN mkdir -p /opt/postprocessing/log && \
     mkdir -p /SNS/IMAGING/IPTS-99999/images && \
     mkdir -p /SNS/IMAGING/shared/autoreduce && \
     touch /SNS/IMAGING/IPTS-99999/nexus/IMAGING_12346.nxs.h5 && \
-    touch /SNS/IMAGING/IPTS-99999/images/image_001.fits && \
-    touch /SNS/IMAGING/IPTS-99999/images/image_002.fits && \
+    touch /SNS/IMAGING/IPTS-99999/images/20260721_Run_12346_series_0001.fits && \
+    touch /SNS/IMAGING/IPTS-99999/images/20260721_Run_12346_series_0002.fits && \
     \
     chown -R root:root /opt/postprocessing /SNS
 

--- a/tests/integration/Dockerfile.oncat
+++ b/tests/integration/Dockerfile.oncat
@@ -11,13 +11,17 @@ RUN mkdir -p /SNS/CORELLI/IPTS-15526/nexus && \
     mkdir -p /SNS/VENUS/IPTS-99999/images && \
     mkdir -p /SNS/VENUS/IPTS-99999/shared/autoreduce && \
     touch /SNS/VENUS/IPTS-99999/nexus/VENUS_12345.nxs.h5 && \
-    touch /SNS/VENUS/IPTS-99999/images/image_001.fits && \
-    touch /SNS/VENUS/IPTS-99999/images/image_002.fits && \
-    touch /SNS/VENUS/IPTS-99999/images/image_003.tiff && \
+    touch /SNS/VENUS/IPTS-99999/nexus/VENUS_12347.nxs.h5 && \
+    touch /SNS/VENUS/IPTS-99999/images/20260721_Run_12345_series_0001.fits && \
+    touch /SNS/VENUS/IPTS-99999/images/20260721_Run_12345_series_0002.fits && \
+    touch /SNS/VENUS/IPTS-99999/images/20260721_Run_12345_series_0003.tiff && \
+    touch /SNS/VENUS/IPTS-99999/images/20260721_Run_12347_series_0001.tiff && \
+    touch /SNS/VENUS/IPTS-99999/images/20260721_Run_12344_series_0001.tiff && \
+    touch /SNS/VENUS/IPTS-99999/images/20260721_Run_123450_series_0001.tiff && \
     \
     mkdir -p /SNS/IMAGING/IPTS-99999/nexus && \
     mkdir -p /SNS/IMAGING/IPTS-99999/images && \
     touch /SNS/IMAGING/IPTS-99999/nexus/IMAGING_12346.nxs.h5 && \
-    touch /SNS/IMAGING/IPTS-99999/images/image_001.fits && \
-    touch /SNS/IMAGING/IPTS-99999/images/image_002.fits
+    touch /SNS/IMAGING/IPTS-99999/images/20260721_Run_12346_series_0001.fits && \
+    touch /SNS/IMAGING/IPTS-99999/images/20260721_Run_12346_series_0002.fits
 CMD ["python", "oncat_server.py"]

--- a/tests/integration/Dockerfile.oncat
+++ b/tests/integration/Dockerfile.oncat
@@ -16,6 +16,7 @@ RUN mkdir -p /SNS/CORELLI/IPTS-15526/nexus && \
     touch /SNS/VENUS/IPTS-99999/images/20260721_Run_12345_series_0002.fits && \
     touch /SNS/VENUS/IPTS-99999/images/20260721_Run_12345_series_0003.tiff && \
     touch /SNS/VENUS/IPTS-99999/images/20260721_Run_12347_series_0001.tiff && \
+    touch /SNS/VENUS/IPTS-99999/images/20250428_20260721_Run_12345_tpx3_0004.tiff && \
     touch /SNS/VENUS/IPTS-99999/images/20260721_Run_12344_series_0001.tiff && \
     touch /SNS/VENUS/IPTS-99999/images/20260721_Run_123450_series_0001.tiff && \
     \

--- a/tests/integration/oncat_server.py
+++ b/tests/integration/oncat_server.py
@@ -106,7 +106,14 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         # IMAGING is a test-only instrument used to exercise the disabled path
         # (it has image metadata and image files, but no catalog_IMAGING.py script).
         if instrument in ("VENUS", "IMAGING"):
-            response["metadata"] = {"entry": {"daslogs": {"bl10:exp:im:imagefilepath": {"value": "images"}}}}
+            # The image file path points at the directory holding a series of
+            # images, except for run 12347, which points at a single image file.
+            # Both forms occur in production, depending on the detector.
+            if run_number == 12347:
+                image_file_path = "images/20260721_Run_12347_series_0001.tiff"
+            else:
+                image_file_path = "images"
+            response["metadata"] = {"entry": {"daslogs": {"bl10:exp:im:imagefilepath": {"value": image_file_path}}}}
 
         self.wfile.write(json.dumps(response).encode("utf-8"))
 

--- a/tests/integration/test_cataloging.py
+++ b/tests/integration/test_cataloging.py
@@ -166,12 +166,16 @@ def test_oncat_catalog_venus_images():
     )
 
     # Check that batch ingestion was called with this run's image files
-    assert any("INFO Received batch datafile ingest request for 3 files" in line for line in log)
+    assert any("INFO Received batch datafile ingest request for 4 files" in line for line in log)
 
-    # Verify all three of this run's image files were logged
+    # Verify all of this run's image files were logged, including the TPX3 form
+    # that carries a second date prefix ahead of the run token
     assert any("INFO   - /SNS/VENUS/IPTS-99999/images/20260721_Run_12345_series_0001.fits" in line for line in log)
     assert any("INFO   - /SNS/VENUS/IPTS-99999/images/20260721_Run_12345_series_0002.fits" in line for line in log)
     assert any("INFO   - /SNS/VENUS/IPTS-99999/images/20260721_Run_12345_series_0003.tiff" in line for line in log)
+    assert any(
+        "INFO   - /SNS/VENUS/IPTS-99999/images/20250428_20260721_Run_12345_tpx3_0004.tiff" in line for line in log
+    )
 
     # The other runs sharing the directory are not cataloged under this run,
     # including the run number that merely extends this one

--- a/tests/integration/test_cataloging.py
+++ b/tests/integration/test_cataloging.py
@@ -108,7 +108,11 @@ def test_oncat_catalog_error():
 
 
 def test_oncat_catalog_venus_images():
-    """This should run ONCatProcessor and catalog VENUS image files using batch API"""
+    """This should run ONCatProcessor and catalog VENUS image files using batch API.
+
+    The image file path points at a directory shared by a series of runs, so only
+    the image files named for run 12345 may be cataloged.
+    """
     message = {
         "run_number": "12345",
         "instrument": "VENUS",
@@ -161,13 +165,75 @@ def test_oncat_catalog_venus_images():
         for line in log
     )
 
-    # Check that batch ingestion was called with the image files
+    # Check that batch ingestion was called with this run's image files
     assert any("INFO Received batch datafile ingest request for 3 files" in line for line in log)
 
-    # Verify all three image files were logged
-    assert any("INFO   - /SNS/VENUS/IPTS-99999/images/image_001.fits" in line for line in log)
-    assert any("INFO   - /SNS/VENUS/IPTS-99999/images/image_002.fits" in line for line in log)
-    assert any("INFO   - /SNS/VENUS/IPTS-99999/images/image_003.tiff" in line for line in log)
+    # Verify all three of this run's image files were logged
+    assert any("INFO   - /SNS/VENUS/IPTS-99999/images/20260721_Run_12345_series_0001.fits" in line for line in log)
+    assert any("INFO   - /SNS/VENUS/IPTS-99999/images/20260721_Run_12345_series_0002.fits" in line for line in log)
+    assert any("INFO   - /SNS/VENUS/IPTS-99999/images/20260721_Run_12345_series_0003.tiff" in line for line in log)
+
+    # The other runs sharing the directory are not cataloged under this run,
+    # including the run number that merely extends this one
+    assert not any("20260721_Run_12344_series_0001.tiff" in line for line in log)
+    assert not any("20260721_Run_123450_series_0001.tiff" in line for line in log)
+
+
+def test_oncat_catalog_venus_single_image_path():
+    """The image file path can point at a single image file rather than a
+    directory. That file is cataloged, and no other file in its directory is.
+    """
+    message = {
+        "run_number": "12347",
+        "instrument": "VENUS",
+        "ipts": "IPTS-99999",
+        "facility": "SNS",
+        "data_file": "/SNS/VENUS/IPTS-99999/nexus/VENUS_12347.nxs.h5",
+    }
+
+    conn = stomp.Connection(host_and_ports=[("localhost", 61613)])
+
+    listener = stomp.listener.TestListener(10)  # 10 second timeout
+    conn.set_listener("", listener)
+
+    try:
+        conn.connect("icat", "icat")
+    except stomp.exception.ConnectFailedException:
+        pytest.skip("Requires activemq running")
+
+    # expect a message on CATALOG.ONCAT.COMPLETE
+    conn.subscribe("/queue/CATALOG.ONCAT.COMPLETE", id="venus12347", ack="auto")
+
+    # send data ready
+    conn.send("/queue/CATALOG.ONCAT.DATA_READY", json.dumps(message).encode())
+
+    # Wait for messages until we get the one for this run
+    max_attempts = 10
+    for _ in range(max_attempts):
+        listener.wait_for_message()
+        header, body = listener.get_latest_message()
+        msg = json.loads(body)
+        if msg["run_number"] == message["run_number"]:
+            break
+    else:
+        pytest.fail(f"Did not receive COMPLETE message for VENUS run {message['run_number']}")
+
+    conn.disconnect()
+
+    assert msg["run_number"] == message["run_number"]
+
+    time.sleep(1)  # give oncat_server time to write its log
+    log = docker_exec_and_cat("/oncat_server.log", "oncat").splitlines()
+
+    # Check that the NeXus file was ingested
+    assert any(
+        "INFO Received datafile ingest request for /SNS/VENUS/IPTS-99999/nexus/VENUS_12347.nxs.h5" in line
+        for line in log
+    )
+
+    # Only the single image file named by the metadata is cataloged
+    assert any("INFO Received batch datafile ingest request for 1 files" in line for line in log)
+    assert any("INFO   - /SNS/VENUS/IPTS-99999/images/20260721_Run_12347_series_0001.tiff" in line for line in log)
 
 
 def test_oncat_catalog_images_disabled():

--- a/tests/unit/postprocessing/processors/test_oncat_processor.py
+++ b/tests/unit/postprocessing/processors/test_oncat_processor.py
@@ -103,25 +103,46 @@ def test_related_files_with_run_number():
 @pytest.mark.parametrize(
     "file_name, expected",
     [
-        # The naming convention the VENUS DAQ follows for every detector
-        ("20260713_Run_24828_long_acq_test_10_000s_0_700AngsMin_0_282.tiff", True),
-        ("20260406_Run_24828_NoSample_res_alarm_ob_0_399_00000.fits", True),
+        # The three naming schemes seen in production, all of which carry a
+        # Run_<run_number> token but not in the same position
+        ("20260713_Run_24828_long_acq_test_10_000s_0_700AngsMin_0_282.tiff", True),  # QHY, Andor, TPX1
+        ("20250428_20260713_Run_24828_HDPErpi_Gd_0__0000_6311657.tiff", True),  # TPX3, two date prefixes
+        ("Run_24828_20250516_May16_2025_OB_5C_0005_3137132_00826.fits", True),  # TPX1 raw/ob, run first
         # Images of the other runs sharing the directory
         ("20260713_Run_24827_long_acq_test_10_000s_0_700AngsMin_0_281.tiff", False),
         ("20260713_Run_24829_long_acq_test_10_000s_0_700AngsMin_1_283.tiff", False),
         # A run number that merely starts with, or extends, the one we want
         ("20260713_Run_2482_long_acq_test.tiff", False),
         ("20260713_Run_248280_long_acq_test.tiff", False),
-        # Names that do not follow the convention at all
-        ("Run_24828_no_date_prefix.tiff", False),
+        # The observed file names all continue with an underscore, but any
+        # non-digit is deliberately accepted: a separator we have not seen should
+        # over-catalog rather than silently catalog nothing for the run
+        ("20260713_Run_24828.tiff", True),
+        ("20260713_Run_24828-long-acq-test.tiff", True),
+        # Names carrying no run number, or the number without the Run_ token
         ("image_001.tiff", False),
         ("20260713_24828_no_run_marker.tiff", False),
+        ("Image004_00027.fits", False),
+        # The token must start the name or follow an underscore
+        ("Rerun_24828_not_a_run_token.tiff", False),
     ],
 )
 def test_matches_run_number(file_name, expected):
-    """Only files named for this run match, and the run number may not be a
-    prefix of a longer run number"""
+    """Only files named for this run match, wherever the Run_<run> token sits in
+    the name, and the run number may not be a prefix of a longer run number"""
     assert matches_run_number("/SNS/VENUS/IPTS-25778/images/qhy411/" + file_name, "24828") is expected
+
+
+def test_matches_run_number_excludes_previous_run_directory_contents():
+    """A stale image file path can point at the previous run's directory, whose
+    files name that run and must not be cataloged under this one"""
+    previous_run_images = [
+        "/SNS/VENUS/IPTS-35790/images/tpx3/raw/Run_7352_DSet0/20250317_Run_7352_ai_loop_0000_2039884.tiff",
+        "/SNS/VENUS/IPTS-37446/images/tpx1/ob/20260305_Run_15289_Chop_Tune_ob_0/"
+        "20260305_Run_15289_Chop_Tune_ob_0_046_01693.fits",
+    ]
+    assert not any(matches_run_number(path, "7353") for path in previous_run_images)
+    assert not any(matches_run_number(path, "15291") for path in previous_run_images)
 
 
 def test_matches_run_number_accepts_non_string_and_padded_run_numbers():

--- a/tests/unit/postprocessing/processors/test_oncat_processor.py
+++ b/tests/unit/postprocessing/processors/test_oncat_processor.py
@@ -1,11 +1,39 @@
 from unittest.mock import Mock, patch
 
+import pytest
+
 from postprocessing.processors.oncat_processor import (
     ONCatProcessor,
     batches,
     related_files,
     image_files,
+    matches_run_number,
 )
+
+METADATA_PATHS = ["metadata.entry.daslogs.bl10:exp:im:imagefilepath.value"]
+
+
+def make_datafile(tmp_path, metadata_value):
+    """A datafile whose /facility/instrument/experiment root is under tmp_path.
+
+    This lets the image file tests run against real files on disk, so the
+    globbing and the run number filtering are exercised for real.
+    """
+    datafile = Mock()
+    datafile.facility = str(tmp_path).lstrip("/")
+    datafile.instrument = "VENUS"
+    datafile.experiment = "IPTS-99999"
+    datafile.get.return_value = metadata_value
+    return datafile
+
+
+def make_image_dir(tmp_path, subdir, file_names):
+    """Create image files under the datafile root and return the directory"""
+    image_dir = tmp_path / "VENUS" / "IPTS-99999" / subdir
+    image_dir.mkdir(parents=True, exist_ok=True)
+    for file_name in file_names:
+        (image_dir / file_name).touch()
+    return image_dir
 
 
 def test_batches_empty_list():
@@ -72,6 +100,38 @@ def test_related_files_with_run_number():
         assert mock_datafile.location not in result
 
 
+@pytest.mark.parametrize(
+    "file_name, expected",
+    [
+        # The naming convention the VENUS DAQ follows for every detector
+        ("20260713_Run_24828_long_acq_test_10_000s_0_700AngsMin_0_282.tiff", True),
+        ("20260406_Run_24828_NoSample_res_alarm_ob_0_399_00000.fits", True),
+        # Images of the other runs sharing the directory
+        ("20260713_Run_24827_long_acq_test_10_000s_0_700AngsMin_0_281.tiff", False),
+        ("20260713_Run_24829_long_acq_test_10_000s_0_700AngsMin_1_283.tiff", False),
+        # A run number that merely starts with, or extends, the one we want
+        ("20260713_Run_2482_long_acq_test.tiff", False),
+        ("20260713_Run_248280_long_acq_test.tiff", False),
+        # Names that do not follow the convention at all
+        ("Run_24828_no_date_prefix.tiff", False),
+        ("image_001.tiff", False),
+        ("20260713_24828_no_run_marker.tiff", False),
+    ],
+)
+def test_matches_run_number(file_name, expected):
+    """Only files named for this run match, and the run number may not be a
+    prefix of a longer run number"""
+    assert matches_run_number("/SNS/VENUS/IPTS-25778/images/qhy411/" + file_name, "24828") is expected
+
+
+def test_matches_run_number_accepts_non_string_and_padded_run_numbers():
+    """The run number comes from the message, so do not depend on its formatting"""
+    file_name = "/SNS/VENUS/IPTS-25778/images/qhy411/20260713_Run_24828_long_acq_test.tiff"
+    assert matches_run_number(file_name, 24828) is True
+    assert matches_run_number(file_name, "024828") is True
+    assert matches_run_number(file_name, " 24828 ") is True
+
+
 def test_image_files_no_metadata():
     """Test image_files when metadata path doesn't exist"""
     mock_datafile = Mock()
@@ -80,85 +140,120 @@ def test_image_files_no_metadata():
     mock_datafile.experiment = "IPTS-99999"
     mock_datafile.get.return_value = None  # No metadata found
 
-    metadata_paths = ["metadata.entry.daslogs.bl10:exp:im:imagefilepath.value"]
-    result = image_files(mock_datafile, metadata_paths)
+    result = image_files(mock_datafile, METADATA_PATHS, "12345")
     assert result == []
 
 
-def test_image_files_metadata_not_a_directory():
-    """Test image_files when metadata points to non-existent directory"""
-    mock_datafile = Mock()
-    mock_datafile.facility = "SNS"
-    mock_datafile.instrument = "VENUS"
-    mock_datafile.experiment = "IPTS-99999"
-    mock_datafile.get.return_value = "images"
+def test_image_files_metadata_neither_file_nor_directory(tmp_path):
+    """Test image_files when metadata points to a location that does not exist"""
+    mock_datafile = make_datafile(tmp_path, "images/does_not_exist")
 
-    with patch("os.path.isdir") as mock_isdir:
-        mock_isdir.return_value = False
-
-        metadata_paths = ["metadata.entry.daslogs.bl10:exp:im:imagefilepath.value"]
-        result = image_files(mock_datafile, metadata_paths)
-        assert result == []
+    result = image_files(mock_datafile, METADATA_PATHS, "12345")
+    assert result == []
 
 
-def test_image_files_single_directory():
-    """Test image_files with single directory containing FITS and TIFF files"""
-    mock_datafile = Mock()
-    mock_datafile.facility = "SNS"
-    mock_datafile.instrument = "VENUS"
-    mock_datafile.experiment = "IPTS-99999"
-    mock_datafile.get.return_value = "images"
+def test_image_files_single_directory(tmp_path):
+    """Only this run's FITS and TIFF files in the directory are cataloged"""
+    image_dir = make_image_dir(
+        tmp_path,
+        "images",
+        [
+            "20260713_Run_12345_series_0001.fits",
+            "20260713_Run_12345_series_0002.fits",
+            "20260713_Run_12345_series_0003.tiff",
+        ],
+    )
+    mock_datafile = make_datafile(tmp_path, "images")
 
-    with patch("os.path.isdir") as mock_isdir, patch("glob.glob") as mock_glob:
-        mock_isdir.return_value = True
+    result = image_files(mock_datafile, METADATA_PATHS, "12345")
 
-        def glob_side_effect(pattern):
-            if pattern.endswith("*.fits"):
-                return [
-                    "/SNS/VENUS/IPTS-99999/images/image_001.fits",
-                    "/SNS/VENUS/IPTS-99999/images/image_002.fits",
-                ]
-            elif pattern.endswith("*.tiff"):
-                return ["/SNS/VENUS/IPTS-99999/images/image_003.tiff"]
-            return []
-
-        mock_glob.side_effect = glob_side_effect
-
-        metadata_paths = ["metadata.entry.daslogs.bl10:exp:im:imagefilepath.value"]
-        result = image_files(mock_datafile, metadata_paths)
-
-        assert len(result) == 3
-        assert "/SNS/VENUS/IPTS-99999/images/image_001.fits" in result
-        assert "/SNS/VENUS/IPTS-99999/images/image_002.fits" in result
-        assert "/SNS/VENUS/IPTS-99999/images/image_003.tiff" in result
+    assert result == [
+        str(image_dir / "20260713_Run_12345_series_0001.fits"),
+        str(image_dir / "20260713_Run_12345_series_0002.fits"),
+        str(image_dir / "20260713_Run_12345_series_0003.tiff"),
+    ]
 
 
-def test_image_files_multiple_directories():
-    """Test image_files with multiple directories (list of subdirectories)"""
-    mock_datafile = Mock()
-    mock_datafile.facility = "SNS"
-    mock_datafile.instrument = "VENUS"
-    mock_datafile.experiment = "IPTS-99999"
-    mock_datafile.get.return_value = ["images/batch1", "images/batch2"]
+def test_image_files_filters_out_other_runs(tmp_path):
+    """A series directory is shared by consecutive runs: catalog only our own
+    images, otherwise every run re-catalogs the images of the runs before it"""
+    image_dir = make_image_dir(
+        tmp_path,
+        "images/qhy411/raw/radiography/20260713_long_acq_test",
+        [
+            "20260713_Run_12344_long_acq_test_0_281.tiff",
+            "20260713_Run_12345_long_acq_test_1_282.tiff",
+            "20260713_Run_12346_long_acq_test_2_283.tiff",
+            "20260713_Run_123450_long_acq_test_3_284.tiff",
+            "20260713_Run_1234_long_acq_test_4_285.tiff",
+        ],
+    )
+    mock_datafile = make_datafile(tmp_path, "images/qhy411/raw/radiography/20260713_long_acq_test")
 
-    with patch("os.path.isdir") as mock_isdir, patch("glob.glob") as mock_glob:
-        mock_isdir.return_value = True
+    result = image_files(mock_datafile, METADATA_PATHS, "12345")
 
-        def glob_side_effect(pattern):
-            if "batch1" in pattern and pattern.endswith("*.fits"):
-                return ["/SNS/VENUS/IPTS-99999/images/batch1/image_001.fits"]
-            elif "batch2" in pattern and pattern.endswith("*.tiff"):
-                return ["/SNS/VENUS/IPTS-99999/images/batch2/image_002.tiff"]
-            return []
+    assert result == [str(image_dir / "20260713_Run_12345_long_acq_test_1_282.tiff")]
 
-        mock_glob.side_effect = glob_side_effect
 
-        metadata_paths = ["metadata.entry.daslogs.bl10:exp:im:imagefilepath.value"]
-        result = image_files(mock_datafile, metadata_paths)
+def test_image_files_single_file_location(tmp_path):
+    """The metadata can point straight at an image file, which is filtered by
+    run number just like the contents of a directory"""
+    image_dir = make_image_dir(tmp_path, "images", ["20260713_Run_12345_series_0001.tiff"])
+    mock_datafile = make_datafile(tmp_path, "images/20260713_Run_12345_series_0001.tiff")
 
-        assert len(result) == 2
-        assert "/SNS/VENUS/IPTS-99999/images/batch1/image_001.fits" in result
-        assert "/SNS/VENUS/IPTS-99999/images/batch2/image_002.tiff" in result
+    result = image_files(mock_datafile, METADATA_PATHS, "12345")
+
+    assert result == [str(image_dir / "20260713_Run_12345_series_0001.tiff")]
+
+
+def test_image_files_single_file_location_of_another_run(tmp_path):
+    """A file naming a different run is not cataloged under this run"""
+    make_image_dir(tmp_path, "images", ["20260713_Run_12344_series_0001.tiff"])
+    mock_datafile = make_datafile(tmp_path, "images/20260713_Run_12344_series_0001.tiff")
+
+    result = image_files(mock_datafile, METADATA_PATHS, "12345")
+
+    assert result == []
+
+
+def test_image_files_multiple_directories(tmp_path):
+    """Test image_files with multiple locations (list of subdirectories).
+
+    MCP TPX1 runs report two locations, the second being the directory of the
+    previous run, whose images must not be cataloged again under this run.
+    """
+    previous_run_dir = make_image_dir(
+        tmp_path,
+        "images/tpx1/raw/20260611_LF99D/20260611_Run_12344_LF99D_24",
+        ["20260611_Run_12344_LF99D_24_360_00000.fits"],
+    )
+    this_run_dir = make_image_dir(
+        tmp_path,
+        "images/tpx1/raw/20260611_LF99D/20260611_Run_12345_LF99D_25",
+        ["20260611_Run_12345_LF99D_25_360_00000.fits"],
+    )
+    mock_datafile = make_datafile(
+        tmp_path,
+        [
+            "images/tpx1/raw/20260611_LF99D/20260611_Run_12344_LF99D_24",
+            "images/tpx1/raw/20260611_LF99D/20260611_Run_12345_LF99D_25",
+        ],
+    )
+
+    result = image_files(mock_datafile, METADATA_PATHS, "12345")
+
+    assert result == [str(this_run_dir / "20260611_Run_12345_LF99D_25_360_00000.fits")]
+    assert not any(str(previous_run_dir) in path for path in result)
+
+
+def test_image_files_ingests_each_file_once(tmp_path):
+    """The same location can be reported more than once"""
+    image_dir = make_image_dir(tmp_path, "images", ["20260713_Run_12345_series_0001.fits"])
+    mock_datafile = make_datafile(tmp_path, ["images", "images"])
+
+    result = image_files(mock_datafile, METADATA_PATHS + ["another.metadata.path"], "12345")
+
+    assert result == [str(image_dir / "20260713_Run_12345_series_0001.fits")]
 
 
 def test_oncat_processor_ingest_with_images():
@@ -213,6 +308,13 @@ def test_oncat_processor_ingest_with_images():
 
         # Verify the main file was ingested
         mock_oncat.Datafile.ingest.assert_called_once()
+
+        # Verify the images were looked up for the run being cataloged
+        mock_images.assert_called_once_with(
+            mock_datafile,
+            mock_conf.image_filepath_metadata_paths,
+            "12345",
+        )
 
         # Verify batch was called with the image files
         mock_oncat.Datafile.batch.assert_called_once_with(


### PR DESCRIPTION
# Short description of the changes:

Catalog only the image files that belong to the run being cataloged, identified by the `Run_<run_number>`
token the VENUS DAQ writes into every image file name. This removes the redundant re-cataloging of earlier
runs' images that was making VENUS image cataloging slow enough to back up the shared autoreducers.

# Long description of the changes:

The image file path PV is meant to name an image file, but for several detectors (QHY, Andor) it names the
directory holding a whole series of images, and consecutive runs of a series share that directory. The agent
cataloged every FITS/TIFF file in that directory, so each run re-cataloged every image written by the runs
before it. The cost grows with the length of the series, and since cataloging produces a thumbnail by reading
the full image, it ended up taking longer than writing the data out.

Checking ONCat for already-ingested files was considered and rejected: it becomes wasteful once a series
has hundreds of images, and it makes a job's behavior depend on the order and success of other jobs.
Per the agreement with the DAQ team, this filters by run number instead, which is a local, self-contained
rule.

Verified against production data before implementing, for each detector family:

| Run | Detector | PV points at | Files in location | Cataloged now |
| --- | --- | --- | --- | --- |
| 24828 (IPTS-25778) | QHY411 | series directory | 881, one per run | 1 |
| 24436 (IPTS-35825) | Andor iKon-XL | series directory | 1 | 1 |
| 17853 (IPTS-25778) | TPX1 | run directory | 1362 | 1362 |
| 23221 (IPTS-36967) | MCP TPX1 | two run directories | 5001 + run 23220's | 5001 |

The 881-file QHY directory is the pathological case from the report: 881 images spanning 881 distinct runs,
of which exactly one belongs to run 24828.

**The run token is matched wherever it appears in the name, not only as a `YYYYMMDD_Run_<run>` prefix.**
The convention quoted in the discussion holds for 114 of 120 recent runs sampled (2026-03 to 2026-06), but
TPX3 prepends a second, fixed date — `20250428_20260310_Run_15395_no_samp_ugg_test_...tiff` — and some 2025
TPX1 data leads with the run token instead (`Run_8787_20250516_...fits`). Anchoring to the start of the name
would catalog **zero** images for those runs while still reporting COMPLETE. Checked end-to-end against 143
runs across every IPTS: the anchored form silently skips 19 of them, matching the token by position skips
none. This also matches the request in the discussion to filter on the run number appearing "somewhere in
the full tiff file path".

Two further findings from that check, both of which the filter now handles correctly:

- Some runs' image path points at the **previous run's** directory (run 7353 -> `.../Run_7352_DSet0`,
  run 15291 -> `..._Run_15289_...`). Those images are no longer cataloged under the wrong run; previously
  6000 and 2075 images respectively were.
- Across the 143 runs, 547,415 candidate images reduce to 326,505 cataloged, so about 40% of the
  cataloging work was redundant. For the QHY series specifically the reduction is 881 -> 1.

Specifics:

- `matches_run_number()` implements the naming rule: a `Run_<run_number>` token that starts the name or
  follows an underscore, and is followed by a non-digit. The trailing boundary matters — otherwise run 2482
  would claim the images of runs 24820-24829, and that is not hypothetical: a substring match on `Run_2482`
  hits 2 files in the QHY directory above, while the bounded match hits 0.
- `image_files()` now takes the run number and filters every candidate through that rule.
- `_image_files_at()` resolves a single location, which may be a file **or** a directory. Both are filtered
  the same way, as agreed — a single file is not assumed to belong to the run naming it. This also fixes a
  latent bug: a PV naming a file was previously dropped by an `os.path.isdir()` guard, so those runs
  cataloged no images at all.
- A metadata path can report several locations, and MCP TPX1 runs report both this run's directory and the
  previous run's; the previous run's images are now filtered out. Duplicate locations ingest once.
- Logging states how many files were skipped as belonging to other runs, how many are being cataloged, and
  warns when a location yields nothing or does not exist.

Out of scope, noted while surveying the data: `.tif` files exist under VENUS images (~1500 in the sampled
IPTS directories) but only `.fits` and `.tiff` are globbed. That is pre-existing behavior, unchanged here.

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [x] I have added tests for my changes
- [x] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer

Unit tests:

    pixi run test-unit

Integration tests (requires Docker):

    docker compose -f tests/integration/docker-compose.yml up -d --build
    pixi run test-integration
    docker compose -f tests/integration/docker-compose.yml down

The VENUS integration fixture directory now holds a series shared by several runs, mirroring production:

- `test_oncat_catalog_venus_images` — run 12345's PV names the directory. Only its 4 files are batched,
  including a TPX3-style name with a second date prefix; runs 12344, 12347 and 123450 (the prefix-collision
  case) are skipped.
- `test_oncat_catalog_venus_single_image_path` — run 12347's PV names a single file, which is batched alone.
- `test_oncat_catalog_images_disabled` — unchanged, confirms the `catalog_<INSTRUMENT>.py` toggle still gates
  the whole substep.

Against a running agent, the log lines to look for are `Skipping N image file(s) in <dir> belonging to other
runs` and `Cataloging N image file(s) for run <run>`.

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if applicable -->
[EWM 17220](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=17220)
