### PR TITLE
Add config for release template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,9 @@
+# Exclude bot PRs from auto-generated release notes
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+      - dependabot[bot]
+      - pre-commit-ci[bot]


### PR DESCRIPTION
I noticed from the last release that this repository doesn't have the template for what PRs to include/exclude from release notes. Here it is, straight from the python-project-template.